### PR TITLE
[FEAT][BE] 닉네임 변경 기능 및 포인트 인증/정책 처리 로직 구현 + 포인트 내역 조회 테스트

### DIFF
--- a/src/main/java/com/ll/quizzle/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/quizzle/domain/member/controller/MemberController.java
@@ -1,53 +1,75 @@
 package com.ll.quizzle.domain.member.controller;
 
+import static com.ll.quizzle.global.exceptions.ErrorCode.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ll.quizzle.domain.member.dto.MemberProfileEditRequestDTO;
+import com.ll.quizzle.domain.member.dto.MemberProfileEditResponseDTO;
 import com.ll.quizzle.domain.member.service.MemberService;
 import com.ll.quizzle.global.response.RsData;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-
-import static com.ll.quizzle.global.exceptions.ErrorCode.REFRESH_TOKEN_NOT_FOUND;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
 public class MemberController {
-    private final MemberService memberService;
+	private final MemberService memberService;
 
-    @DeleteMapping
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void logout(HttpServletRequest request, HttpServletResponse response) {
-        memberService.logout(request, response);
-    }
+	@DeleteMapping
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void logout(HttpServletRequest request, HttpServletResponse response) {
+		memberService.logout(request, response);
+	}
 
-    @PostMapping("/refresh")
-    public RsData<String> refresh(HttpServletRequest request) {
-        String refreshToken = null;
-        Cookie[] cookies = request.getCookies();
+	@PostMapping("/refresh")
+	public RsData<String> refresh(HttpServletRequest request) {
+		String refreshToken = null;
+		Cookie[] cookies = request.getCookies();
 
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if ("refresh_token".equals(cookie.getName())) {
-                    refreshToken = cookie.getValue();
-                    break;
-                }
-            }
-        }
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if ("refresh_token".equals(cookie.getName())) {
+					refreshToken = cookie.getValue();
+					break;
+				}
+			}
+		}
 
-        if (refreshToken == null) {
-            String authHeader = request.getHeader("Authorization");
-            if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                refreshToken = authHeader.substring(7);
-            }
-        }
+		if (refreshToken == null) {
+			String authHeader = request.getHeader("Authorization");
+			if (authHeader != null && authHeader.startsWith("Bearer ")) {
+				refreshToken = authHeader.substring(7);
+			}
+		}
 
-        if (refreshToken == null) {
-            REFRESH_TOKEN_NOT_FOUND.throwServiceException();
-        }
+		if (refreshToken == null) {
+			REFRESH_TOKEN_NOT_FOUND.throwServiceException();
+		}
 
-        return memberService.refreshAccessToken(refreshToken);
-    }
+		return memberService.refreshAccessToken(refreshToken);
+	}
+
+	@PatchMapping("/{memberId}")
+	public RsData<MemberProfileEditResponseDTO> updateProfile(
+		@PathVariable Long memberId,
+		@RequestBody @Valid MemberProfileEditRequestDTO request
+	) {
+		MemberProfileEditResponseDTO response = memberService.updateProfile(memberId, request.nickname());
+		return RsData.success(HttpStatus.OK, response);
+	}
+
 }

--- a/src/main/java/com/ll/quizzle/domain/member/dto/MemberProfileEditRequestDTO.java
+++ b/src/main/java/com/ll/quizzle/domain/member/dto/MemberProfileEditRequestDTO.java
@@ -1,0 +1,12 @@
+package com.ll.quizzle.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MemberProfileEditRequestDTO(
+
+	@NotBlank(message = "닉네임은 필수입니다.")
+	@Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
+	String nickname
+) {
+}

--- a/src/main/java/com/ll/quizzle/domain/member/dto/MemberProfileEditResponseDTO.java
+++ b/src/main/java/com/ll/quizzle/domain/member/dto/MemberProfileEditResponseDTO.java
@@ -1,0 +1,13 @@
+package com.ll.quizzle.domain.member.dto;
+
+import com.ll.quizzle.domain.member.entity.Member;
+
+public record MemberProfileEditResponseDTO(
+	Long id,
+	String profile
+) {
+	public static MemberProfileEditResponseDTO from(Member member) {
+		return new MemberProfileEditResponseDTO(member.getId(), member.getNickname());
+	}
+}
+

--- a/src/main/java/com/ll/quizzle/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/quizzle/domain/member/entity/Member.java
@@ -1,18 +1,24 @@
 package com.ll.quizzle.domain.member.entity;
 
-import com.ll.quizzle.domain.member.type.Role;
-import com.ll.quizzle.global.jpa.entity.BaseEntity;
-import com.ll.quizzle.global.security.oauth2.entity.OAuth;
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.ll.quizzle.global.exceptions.ErrorCode.*;
+import com.ll.quizzle.domain.member.type.Role;
+import com.ll.quizzle.global.jpa.entity.BaseEntity;
+import com.ll.quizzle.global.security.oauth2.entity.OAuth;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -20,87 +26,91 @@ import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Member extends BaseEntity {
-    @Column(nullable = false)
-    private String nickname;
+	@Column(nullable = false)
+	private String nickname;
 
-    @Column(nullable = false)
-    private String email;
+	@Column(nullable = false)
+	private String email;
 
-    @Column(nullable = false)
-    private int level;
+	@Column(nullable = false)
+	private int level;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Role role;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Role role;
 
-    @Column(nullable = false)
-    private int exp;
+	@Column(nullable = false)
+	private int exp;
 
-    @Column(nullable = false)
-    private String profilePath;
+	@Column(nullable = false)
+	private String profilePath;
 
-    @Column(nullable = false)
-    private int pointBalance;
+	@Column(nullable = false)
+	private int pointBalance;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    @Builder.Default
-    private List<OAuth> oauths = new ArrayList<>();
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+	@Builder.Default
+	private List<OAuth> oauths = new ArrayList<>();
 
-    public String getUserRole() {
-        return this.role.name();
-    }
+	public String getUserRole() {
+		return this.role.name();
+	}
 
-    public OAuth getFirstOAuth() {
-        return this.oauths.isEmpty() ? null : this.oauths.get(0);
-    }
+	public OAuth getFirstOAuth() {
+		return this.oauths.isEmpty() ? null : this.oauths.get(0);
+	}
 
-    public boolean isAdmin() {
-        return this.role == Role.ADMIN;
-    }
+	public boolean isAdmin() {
+		return this.role == Role.ADMIN;
+	}
 
+	public boolean isMember() {
+		return this.role == Role.MEMBER;
+	}
 
-    public boolean isMember() {
-        return this.role == Role.MEMBER;
-    }
+	/**
+	 * 포인트 증가
+	 *
+	 * @param amount 증가할 포인트 양 (양수)
+	 */
+	public void increasePoint(int amount) {
+		if (amount <= 0) {
+			POINT_INCREASE_AMOUNT_INVALID.throwServiceException();
+		}
+		this.pointBalance += amount;
+	}
 
-    /**
-     * 포인트 증가
-     *
-     * @param amount 증가할 포인트 양 (양수)
-     */
-    public void increasePoint(int amount) {
-        if (amount <= 0) {
-            POINT_INCREASE_AMOUNT_INVALID.throwServiceException();
-        }
-        this.pointBalance += amount;
-    }
+	/**
+	 * 포인트 차감
+	 *
+	 * @param amount 차감할 포인트 양 (양수)
+	 */
+	public void decreasePoint(int amount) {
+		if (amount <= 0) {
+			POINT_DECREASE_AMOUNT_INVALID.throwServiceException();
+		}
 
-    /**
-     * 포인트 차감
-     *
-     * @param amount 차감할 포인트 양 (양수)
-     */
-    public void decreasePoint(int amount) {
-        if (amount <= 0) {
-            POINT_DECREASE_AMOUNT_INVALID.throwServiceException();
-        }
+		if (this.pointBalance < amount) {
+			POINT_NOT_ENOUGH.throwServiceException();
+		}
 
-        if (this.pointBalance < amount) {
-            POINT_NOT_ENOUGH.throwServiceException();
-        }
+		this.pointBalance -= amount;
+	}
 
-        this.pointBalance -= amount;
-    }
+	public static Member create(String nickname, String email) {
+		return Member.builder()
+			.nickname(nickname)
+			.email(email)
+			.level(0)
+			.role(Role.MEMBER)
+			.exp(0)
+			.profilePath("기본경로")
+			.pointBalance(0)
+			.build();
+	}
 
-    public static Member create(String nickname, String email) {
-        return Member.builder()
-                .nickname(nickname)
-                .email(email)
-                .level(0)
-                .role(Role.MEMBER)
-                .exp(0)
-                .profilePath("기본경로")
-                .pointBalance(0)
-                .build();
-    }
+	public void changeNickname(String nickname) {
+		// Todo:닉네임 유효성 검사 또는 중복 검사 필요 시 여기에 추가
+		this.nickname = nickname;
+	}
 }

--- a/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
@@ -1,20 +1,6 @@
 package com.ll.quizzle.domain.member.service;
 
-import com.ll.quizzle.domain.member.entity.Member;
-import com.ll.quizzle.domain.member.repository.MemberRepository;
-import com.ll.quizzle.global.jwt.dto.GeneratedToken;
-import com.ll.quizzle.global.jwt.dto.JwtProperties;
-import com.ll.quizzle.global.request.Rq;
-import com.ll.quizzle.global.response.RsData;
-import com.ll.quizzle.global.security.oauth2.repository.OAuthRepository;
-import com.ll.quizzle.standard.util.Ut;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -22,153 +8,185 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static com.ll.quizzle.global.exceptions.ErrorCode.*;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ll.quizzle.domain.member.dto.MemberProfileEditResponseDTO;
+import com.ll.quizzle.domain.member.entity.Member;
+import com.ll.quizzle.domain.member.repository.MemberRepository;
+import com.ll.quizzle.domain.point.service.PointService;
+import com.ll.quizzle.domain.point.type.PointReason;
+import com.ll.quizzle.global.jwt.dto.GeneratedToken;
+import com.ll.quizzle.global.jwt.dto.JwtProperties;
+import com.ll.quizzle.global.request.Rq;
+import com.ll.quizzle.global.response.RsData;
+import com.ll.quizzle.global.security.oauth2.repository.OAuthRepository;
+import com.ll.quizzle.standard.util.Ut;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-    private final MemberRepository memberRepository;
-    private final OAuthRepository oAuthRepository;
-    private final RefreshTokenService refreshTokenService;
-    private final RedisTemplate<String, String> redisTemplate;
-    private final AuthTokenService authTokenService;
-    private final JwtProperties jwtProperties;
-    private final Rq rq;
+	private final MemberRepository memberRepository;
+	private final PointService pointService;
+	private final OAuthRepository oAuthRepository;
+	private final RefreshTokenService refreshTokenService;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final AuthTokenService authTokenService;
+	private final JwtProperties jwtProperties;
+	private final Rq rq;
 
-    private static final String LOGOUT_PREFIX = "LOGOUT:";
+	private static final String LOGOUT_PREFIX = "LOGOUT:";
 
-    @Transactional(readOnly = true)
-    public Member findByProviderAndOauthId(String provider, String oauthId) {
-        return oAuthRepository.findByProviderAndOauthIdWithMember(provider, oauthId)
-                .orElseThrow(OAUTH_NOT_FOUND::throwServiceException)
-                .getMember();
-    }
+	@Transactional(readOnly = true)
+	public Member findByProviderAndOauthId(String provider, String oauthId) {
+		return oAuthRepository.findByProviderAndOauthIdWithMember(provider, oauthId)
+			.orElseThrow(OAUTH_NOT_FOUND::throwServiceException)
+			.getMember();
+	}
 
-    public String generateRefreshToken(String email) {
-        return refreshTokenService.generateRefreshToken(email);
-    }
+	public String generateRefreshToken(String email) {
+		return refreshTokenService.generateRefreshToken(email);
+	}
 
-    public String extractEmailIfValid(String token) {
-        if (isLoggedOut(token)) {
-            TOKEN_LOGGED_OUT.throwServiceException();
-        }
-        if (!verifyToken(token)) {
-            TOKEN_INVALID.throwServiceException();
-        }
-        return getEmailFromToken(token);
-    }
+	public String extractEmailIfValid(String token) {
+		if (isLoggedOut(token)) {
+			TOKEN_LOGGED_OUT.throwServiceException();
+		}
+		if (!verifyToken(token)) {
+			TOKEN_INVALID.throwServiceException();
+		}
+		return getEmailFromToken(token);
+	}
 
-    public boolean isLoggedOut(String token) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(LOGOUT_PREFIX + token));
-    }
+	public boolean isLoggedOut(String token) {
+		return Boolean.TRUE.equals(redisTemplate.hasKey(LOGOUT_PREFIX + token));
+	}
 
-    public boolean verifyToken(String accessToken) {
-        return authTokenService.verifyToken(accessToken);
-    }
+	public boolean verifyToken(String accessToken) {
+		return authTokenService.verifyToken(accessToken);
+	}
 
-    public String getEmailFromToken(String token) {
-        return authTokenService.getEmail(token);
-    }
+	public String getEmailFromToken(String token) {
+		return authTokenService.getEmail(token);
+	}
 
-    public RsData<String> refreshAccessToken(String refreshToken) {
-        return refreshTokenService.refreshAccessToken(refreshToken);
-    }
+	public RsData<String> refreshAccessToken(String refreshToken) {
+		return refreshTokenService.refreshAccessToken(refreshToken);
+	}
 
-    @Transactional
-    public void oAuth2Login(Member member, HttpServletResponse response) {
-        GeneratedToken tokens = authTokenService.generateToken(
-                member.getEmail(),
-                member.getUserRole()
-        );
+	@Transactional
+	public void oAuth2Login(Member member, HttpServletResponse response) {
+		GeneratedToken tokens = authTokenService.generateToken(
+			member.getEmail(),
+			member.getUserRole()
+		);
 
-        addAuthCookies(response, tokens, member);
-    }
+		addAuthCookies(response, tokens, member);
+	}
 
-    private void addAuthCookies(HttpServletResponse response, GeneratedToken tokens, Member member) {
-        // Access Token 쿠키
-        Cookie accessTokenCookie = new Cookie("access_token", tokens.accessToken());
-        accessTokenCookie.setPath("/");
-        accessTokenCookie.setHttpOnly(true);
-        response.addCookie(accessTokenCookie);
+	private void addAuthCookies(HttpServletResponse response, GeneratedToken tokens, Member member) {
+		// Access Token 쿠키
+		Cookie accessTokenCookie = new Cookie("access_token", tokens.accessToken());
+		accessTokenCookie.setPath("/");
+		accessTokenCookie.setHttpOnly(true);
+		response.addCookie(accessTokenCookie);
 
-        // Refresh Token 쿠키
-        Cookie refreshTokenCookie = new Cookie("refresh_token", tokens.refreshToken());
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setHttpOnly(true);
-        response.addCookie(refreshTokenCookie);
+		// Refresh Token 쿠키
+		Cookie refreshTokenCookie = new Cookie("refresh_token", tokens.refreshToken());
+		refreshTokenCookie.setPath("/");
+		refreshTokenCookie.setHttpOnly(true);
+		response.addCookie(refreshTokenCookie);
 
-        // Role 쿠키
-        Map<String, Object> roleData = new HashMap<>();
-        roleData.put("role", member.getUserRole());
+		// Role 쿠키
+		Map<String, Object> roleData = new HashMap<>();
+		roleData.put("role", member.getUserRole());
 
-        Cookie roleCookie = new Cookie("role", URLEncoder.encode(Ut.json.toString(roleData), StandardCharsets.UTF_8));
-        roleCookie.setPath("/");
-        response.addCookie(roleCookie);
-    }
+		Cookie roleCookie = new Cookie("role", URLEncoder.encode(Ut.json.toString(roleData), StandardCharsets.UTF_8));
+		roleCookie.setPath("/");
+		response.addCookie(roleCookie);
+	}
 
-    public void logout(HttpServletRequest request, HttpServletResponse response) {
-        Cookie[] cookies = request.getCookies();
-        String accessToken = null;
-        String refreshToken = null;
+	public void logout(HttpServletRequest request, HttpServletResponse response) {
+		Cookie[] cookies = request.getCookies();
+		String accessToken = null;
+		String refreshToken = null;
 
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if ("access_token".equals(cookie.getName())) {
-                    accessToken = cookie.getValue();
-                } else if ("refresh_token".equals(cookie.getName())) {
-                    refreshToken = cookie.getValue();
-                }
-            }
-        }
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if ("access_token".equals(cookie.getName())) {
+					accessToken = cookie.getValue();
+				} else if ("refresh_token".equals(cookie.getName())) {
+					refreshToken = cookie.getValue();
+				}
+			}
+		}
 
-        // 액세스 토큰이 만료되었다면 리프레시 토큰으로 처리
-        if (accessToken == null && refreshToken != null) {
-            RsData<String> refreshResult = refreshAccessToken(refreshToken);
-            if (refreshResult.isSuccess()) {
-                accessToken = refreshResult.getData();
-            }
-        }
+		// 액세스 토큰이 만료되었다면 리프레시 토큰으로 처리
+		if (accessToken == null && refreshToken != null) {
+			RsData<String> refreshResult = refreshAccessToken(refreshToken);
+			if (refreshResult.isSuccess()) {
+				accessToken = refreshResult.getData();
+			}
+		}
 
-        if (accessToken == null) {
-            UNAUTHORIZED.throwServiceException();
-        }
+		if (accessToken == null) {
+			UNAUTHORIZED.throwServiceException();
+		}
 
-        String email = authTokenService.getEmail(accessToken);
+		String email = authTokenService.getEmail(accessToken);
 
-        // Redis에서 토큰 무효화
-        redisTemplate.opsForValue().set(
-                LOGOUT_PREFIX + accessToken,
-                email,
-                jwtProperties.getAccessTokenExpiration(),
-                TimeUnit.MILLISECONDS
-        );
+		// Redis에서 토큰 무효화
+		redisTemplate.opsForValue().set(
+			LOGOUT_PREFIX + accessToken,
+			email,
+			jwtProperties.getAccessTokenExpiration(),
+			TimeUnit.MILLISECONDS
+		);
 
-        // Refresh 토큰 삭제
-        refreshTokenService.removeRefreshToken(email);
+		// Refresh 토큰 삭제
+		refreshTokenService.removeRefreshToken(email);
 
-        deleteCookie(response);
-    }
+		deleteCookie(response);
+	}
 
-    private static void deleteCookie(HttpServletResponse response) {
-        Cookie accessTokenCookie = new Cookie("access_token", null);
-        accessTokenCookie.setMaxAge(0);
-        accessTokenCookie.setPath("/");
+	private static void deleteCookie(HttpServletResponse response) {
+		Cookie accessTokenCookie = new Cookie("access_token", null);
+		accessTokenCookie.setMaxAge(0);
+		accessTokenCookie.setPath("/");
 
-        Cookie roleCookie = new Cookie("role", null);
-        roleCookie.setMaxAge(0);
-        roleCookie.setPath("/");
+		Cookie roleCookie = new Cookie("role", null);
+		roleCookie.setMaxAge(0);
+		roleCookie.setPath("/");
 
-        Cookie refreshTokenCookie = new Cookie("refresh_token", null);
-        refreshTokenCookie.setMaxAge(0);
-        refreshTokenCookie.setPath("/");
+		Cookie refreshTokenCookie = new Cookie("refresh_token", null);
+		refreshTokenCookie.setMaxAge(0);
+		refreshTokenCookie.setPath("/");
 
-        Cookie oauth2AuthRequestCookie = new Cookie("oauth2_auth_request", null);
-        oauth2AuthRequestCookie.setMaxAge(0);
-        oauth2AuthRequestCookie.setPath("/");
+		Cookie oauth2AuthRequestCookie = new Cookie("oauth2_auth_request", null);
+		oauth2AuthRequestCookie.setMaxAge(0);
+		oauth2AuthRequestCookie.setPath("/");
 
-        response.addCookie(accessTokenCookie);
-        response.addCookie(roleCookie);
-        response.addCookie(refreshTokenCookie);
-        response.addCookie(oauth2AuthRequestCookie);
-    }
+		response.addCookie(accessTokenCookie);
+		response.addCookie(roleCookie);
+		response.addCookie(refreshTokenCookie);
+		response.addCookie(oauth2AuthRequestCookie);
+	}
+
+	@Transactional
+	public MemberProfileEditResponseDTO updateProfile(Long targetMemberId, String newNickname) {
+		rq.assertIsOwner(targetMemberId);
+
+		Member actor = rq.getActor();
+		actor.changeNickname(newNickname);
+		pointService.applyPointPolicy(actor, PointReason.NICKNAME_CHANGE);
+
+		return MemberProfileEditResponseDTO.from(actor);
+	}
+
 }

--- a/src/main/java/com/ll/quizzle/domain/point/controller/PointController.java
+++ b/src/main/java/com/ll/quizzle/domain/point/controller/PointController.java
@@ -25,7 +25,7 @@ public class PointController {
 
 	@GetMapping("/{memberId}/points")
 	public RsData<PageDto<PointHistoryResponseDTO>> getPointHistories(
-		@PathVariable Long memberId,
+		@PathVariable("memberId") Long memberId,
 		@RequestParam(defaultValue = "ALL") PointType type,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size

--- a/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
+++ b/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
@@ -1,5 +1,7 @@
 package com.ll.quizzle.domain.point.service;
 
+import static com.ll.quizzle.global.exceptions.ErrorCode.*;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +15,8 @@ import com.ll.quizzle.domain.point.entity.Point;
 import com.ll.quizzle.domain.point.repository.PointRepository;
 import com.ll.quizzle.domain.point.type.PointReason;
 import com.ll.quizzle.domain.point.type.PointType;
+import com.ll.quizzle.global.exceptions.ErrorCode;
+import com.ll.quizzle.global.request.Rq;
 import com.ll.quizzle.standard.page.dto.PageDto;
 
 import lombok.RequiredArgsConstructor;
@@ -23,13 +27,15 @@ public class PointService {
 
 	private final PointRepository pointRepository;
 	private final MemberRepository memberRepository;
+	private final Rq rq;
 
 	public PageDto<PointHistoryResponseDTO> getPointHistoriesWithPage(Long memberId,
 		PointHistoryRequestDTO requestDto) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
 
-		//TODO: 로그인한 사용자와 memberId 일치 여부 검증 (Security 적용 후 추가)
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(MEMBER_NOT_FOUND::throwServiceException);
+
+		rq.assertIsOwner(memberId);
 
 		Pageable pageable = PageRequest.of(requestDto.page(), requestDto.size());
 
@@ -44,22 +50,27 @@ public class PointService {
 		return new PageDto<>(page.map(PointHistoryResponseDTO::from));
 	}
 
-	//포인트 사용
+	// 포인트 사용
 	public void usePoint(Member member, int amount, PointReason reason) {
-		member.decreasePoint(amount);
+		member.decreasePoint(amount); // ↓ 여기서 POINT_NOT_ENOUGH 예외 처리되어야 함
 		Point point = Point.use(member, amount, reason);
 		pointRepository.save(point);
 	}
 
-	//포인트 획득
+	// 포인트 획득
 	public void gainPoint(Member member, int amount, PointReason reason) {
 		member.increasePoint(amount);
 		Point point = Point.gain(member, amount, reason);
 		pointRepository.save(point);
 	}
 
+	// 정책 기반 포인트 처리
 	public void applyPointPolicy(Member member, PointReason reason) {
 		int amount = reason.getDefaultAmount();
+
+		if (amount == 0) {
+			throw ErrorCode.POINT_POLICY_NOT_FOUND.throwServiceException();
+		}
 
 		if (amount > 0) {
 			gainPoint(member, amount, reason);
@@ -67,5 +78,4 @@ public class PointService {
 			usePoint(member, -amount, reason);
 		}
 	}
-
 }

--- a/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
+++ b/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
@@ -52,7 +52,7 @@ public class PointService {
 
 	// 포인트 사용
 	public void usePoint(Member member, int amount, PointReason reason) {
-		member.decreasePoint(amount); // ↓ 여기서 POINT_NOT_ENOUGH 예외 처리되어야 함
+		member.decreasePoint(amount);
 		Point point = Point.use(member, amount, reason);
 		pointRepository.save(point);
 	}

--- a/src/main/java/com/ll/quizzle/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/quizzle/global/exceptions/ErrorCode.java
@@ -1,45 +1,51 @@
 package com.ll.quizzle.global.exceptions;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 @Slf4j
 public enum ErrorCode {
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
 
-    // 포인트
-    POINT_INCREASE_AMOUNT_INVALID(HttpStatus.BAD_REQUEST, "증가 포인트는 0보다 커야 합니다."),
-    POINT_DECREASE_AMOUNT_INVALID(HttpStatus.BAD_REQUEST, "차감 포인트는 0보다 커야 합니다."),
-    POINT_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
+	// point
+	POINT_INCREASE_AMOUNT_INVALID(HttpStatus.BAD_REQUEST, "증가 포인트는 0보다 커야 합니다."),
+	POINT_DECREASE_AMOUNT_INVALID(HttpStatus.BAD_REQUEST, "차감 포인트는 0보다 커야 합니다."),
+	POINT_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
+	INVALID_POINT_REASON(HttpStatus.BAD_REQUEST, "유효하지 않은 포인트 사유입니다."),
+	POINT_POLICY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "포인트 정책이 정의되지 않았습니다."),
 
-    // jwt
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "리프레시 토큰을 찾을 수 없습니다."),
-    REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
+	// jwt
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+	TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
+	REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "리프레시 토큰을 찾을 수 없습니다."),
+	REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
 
-    // member + oauth
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원이 존재하지 않습니다."),
-    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
-    OAUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 OAuth 정보를 찾을 수 없습니다."),
-    OAUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 로그인에 실패했습니다.");
+	// member + oauth
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원이 존재하지 않습니다."),
+	EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
+	OAUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 OAuth 정보를 찾을 수 없습니다."),
+	OAUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 로그인에 실패했습니다."),
 
+	// Global
+	FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+	INVALID_PAGE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 페이지 요청입니다.");
 
-    private final HttpStatus httpStatus;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String message;
 
-    public ServiceException throwServiceException() {
-        throw new ServiceException(httpStatus, message);
-    }
+	public ServiceException throwServiceException() {
+		throw new ServiceException(httpStatus, message);
+	}
 
-    public ServiceException throwServiceException(Throwable cause) {
-        throw new ServiceException(httpStatus, message, cause);
-    }
+	public ServiceException throwServiceException(Throwable cause) {
+		throw new ServiceException(httpStatus, message, cause);
+	}
 }

--- a/src/main/java/com/ll/quizzle/global/request/Rq.java
+++ b/src/main/java/com/ll/quizzle/global/request/Rq.java
@@ -1,34 +1,45 @@
 package com.ll.quizzle.global.request;
 
-import com.ll.quizzle.domain.member.entity.Member;
-import com.ll.quizzle.domain.member.repository.MemberRepository;
-import com.ll.quizzle.global.exceptions.ErrorCode;
-import com.ll.quizzle.global.security.oauth2.dto.SecurityUser;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
-import java.util.Optional;
+import com.ll.quizzle.domain.member.entity.Member;
+import com.ll.quizzle.domain.member.repository.MemberRepository;
+import com.ll.quizzle.global.exceptions.ErrorCode;
+import com.ll.quizzle.global.security.oauth2.dto.SecurityUser;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequestScope
 @RequiredArgsConstructor
 public class Rq {
-    private final MemberRepository memberRepository;
-    private Member actor;
+	private final MemberRepository memberRepository;
+	private Member actor;
 
-    public Member getActor() {
-        if (actor == null) {
-            actor = Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
-                    .map(Authentication::getPrincipal)
-                    .filter(principal -> principal instanceof SecurityUser)
-                    .map(principal -> (SecurityUser) principal)
-                    .flatMap(securityUser -> memberRepository.findByEmail(securityUser.getEmail()))
-                    .orElseThrow(ErrorCode.UNAUTHORIZED::throwServiceException);
-        }
+	public Member getActor() {
+		if (actor == null) {
+			actor = Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+				.map(Authentication::getPrincipal)
+				.filter(principal -> principal instanceof SecurityUser)
+				.map(principal -> (SecurityUser)principal)
+				.flatMap(securityUser -> memberRepository.findByEmail(securityUser.getEmail()))
+				.orElseThrow(ErrorCode.UNAUTHORIZED::throwServiceException);
+		}
 
-        return actor;
-    }
+		return actor;
+	}
+
+	public void assertIsOwner(Long targetMemberId) {
+		Member actor = getActor();
+
+		if (!actor.getId().equals(targetMemberId)) {
+			throw ErrorCode.FORBIDDEN_ACCESS.throwServiceException();
+		}
+	}
+
 }

--- a/src/test/java/com/ll/quizzle/domain/point/PointControllerTest.java
+++ b/src/test/java/com/ll/quizzle/domain/point/PointControllerTest.java
@@ -1,0 +1,121 @@
+package com.ll.quizzle.domain.point;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ll.quizzle.domain.member.entity.Member;
+import com.ll.quizzle.domain.member.repository.MemberRepository;
+import com.ll.quizzle.domain.member.service.AuthTokenService;
+import com.ll.quizzle.domain.point.repository.PointRepository;
+import com.ll.quizzle.factory.PointTestFactory;
+import com.ll.quizzle.factory.TestMemberFactory;
+import com.ll.quizzle.global.jwt.dto.GeneratedToken;
+import com.ll.quizzle.global.security.oauth2.repository.OAuthRepository;
+
+import jakarta.servlet.http.Cookie;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class PointControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private PointRepository pointRepository;
+
+	@Autowired
+	private AuthTokenService authTokenService;
+
+	@Autowired
+	private OAuthRepository oAuthRepository;
+
+	private Member member;
+	private Member other;
+	private Cookie accessTokenCookie;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트 유저 생성
+		member = TestMemberFactory.createOAuthMember(
+			"테스트유저", "test@email.com", "google", "1234",
+			memberRepository, oAuthRepository
+		);
+
+		other = TestMemberFactory.createOAuthMember(
+			"다른유저", "other@email.com", "google", "5678",
+			memberRepository, oAuthRepository
+		);
+
+		// 포인트 내역 생성
+		PointTestFactory.createRewardPoint(member, pointRepository, 100);
+		PointTestFactory.createUsePoint(member, pointRepository, 30);
+
+		// 인증 토큰 생성 및 쿠키 설정
+		GeneratedToken token = authTokenService.generateToken(member.getEmail(), member.getRole().name());
+		accessTokenCookie = new Cookie("access_token", token.accessToken());
+	}
+
+	@Test
+	@DisplayName("포인트 내역 전체 조회 성공")
+	void getPoints_success() throws Exception {
+		mockMvc.perform(get("/api/v1/members/" + member.getId() + "/points")
+				.cookie(accessTokenCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.items").isArray())
+			.andExpect(jsonPath("$.data.items.length()").value(2));
+	}
+
+	@Test
+	@DisplayName("REWARD 타입 필터링 조회")
+	void getPoints_rewardOnly() throws Exception {
+		mockMvc.perform(get("/api/v1/members/" + member.getId() + "/points")
+				.param("type", "REWARD")
+				.cookie(accessTokenCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.items.length()").value(1))
+			.andExpect(jsonPath("$.data.items[0].type").value("REWARD"));
+	}
+
+	@Test
+	@DisplayName("USE 타입 필터링 조회")
+	void getPoints_useOnly() throws Exception {
+		mockMvc.perform(get("/api/v1/members/" + member.getId() + "/points")
+				.param("type", "USE")
+				.cookie(accessTokenCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.items.length()").value(1))
+			.andExpect(jsonPath("$.data.items[0].type").value("USE"));
+	}
+
+	@Test
+	@DisplayName("인증되지 않은 사용자 → 401")
+	void getPoints_unauthorized() throws Exception {
+		mockMvc.perform(get("/api/v1/members/" + member.getId() + "/points"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("다른 유저의 포인트 내역 조회 시 → 403")
+	void getPoints_forbidden() throws Exception {
+		GeneratedToken otherToken = authTokenService.generateToken(other.getEmail(), other.getRole().name());
+		Cookie otherCookie = new Cookie("access_token", otherToken.accessToken());
+
+		mockMvc.perform(get("/api/v1/members/" + member.getId() + "/points")
+				.cookie(otherCookie))
+			.andExpect(status().isForbidden());
+	}
+}

--- a/src/test/java/com/ll/quizzle/factory/PointTestFactory.java
+++ b/src/test/java/com/ll/quizzle/factory/PointTestFactory.java
@@ -1,0 +1,20 @@
+package com.ll.quizzle.factory;
+
+import com.ll.quizzle.domain.member.entity.Member;
+import com.ll.quizzle.domain.point.entity.Point;
+import com.ll.quizzle.domain.point.repository.PointRepository;
+import com.ll.quizzle.domain.point.type.PointReason;
+
+public class PointTestFactory {
+
+	public static void createRewardPoint(Member member, PointRepository repo, int amount) {
+		member.increasePoint(amount);
+		repo.save(Point.gain(member, amount, PointReason.LEVEL_UP));
+	}
+
+	public static void createUsePoint(Member member, PointRepository repo, int amount) {
+		member.decreasePoint(amount);
+		repo.save(Point.use(member, amount, PointReason.NICKNAME_CHANGE));
+	}
+
+}

--- a/src/test/java/com/ll/quizzle/factory/TestMemberFactory.java
+++ b/src/test/java/com/ll/quizzle/factory/TestMemberFactory.java
@@ -1,0 +1,20 @@
+package com.ll.quizzle.factory;
+
+import com.ll.quizzle.domain.member.entity.Member;
+import com.ll.quizzle.domain.member.repository.MemberRepository;
+import com.ll.quizzle.global.security.oauth2.entity.OAuth;
+import com.ll.quizzle.global.security.oauth2.repository.OAuthRepository;
+
+public class TestMemberFactory {
+
+	public static Member createOAuthMember(String nickname, String email, String provider, String oauthId,
+		MemberRepository memberRepo, OAuthRepository oauthRepo) {
+		Member member = Member.create(nickname, email);
+		memberRepo.save(member);
+
+		OAuth oauth = OAuth.create(member, provider, oauthId);
+		oauthRepo.save(oauth);
+
+		return member;
+	}
+}


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 닉네임 변경 기능 및 포인트 인증/정책 처리 로직 구현 -->
<!-- #1  -->

## 📝Part
- [x] BE
- [ ] FE

<br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

<br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?
  → **닉네임 변경 및 포인트 관련 통합 테스트는 이후 작성 예정**

<br/>

## 🔎 작업 내용

### 1. 닉네임 변경 기능 구현
- `PATCH /api/v1/members/{memberId}` API 구현
- `MemberProfileEditRequestDTO`, `UserProfileEditResponseDto` 생성
- 닉네임 변경 시 `PointService.applyPointPolicy()` 호출

### 2. 포인트 정책 및 예외 처리
- `PointReason.NICKNAME_CHANGE`에 대한 포인트 차감 연동
- 포인트 부족, 잘못된 요청에 대한 `ErrorCode` 예외 정의

### 3. 사용자 인증 검증 로직 적용
- `Rq.assertIsOwner(memberId)` 메서드 추가
- 본인이 아닌 경우 `FORBIDDEN_ACCESS` 예외 발생

### 4. 포인트 내역 조회 인증 검증
- `PointService.getPointHistoriesWithPage()`에 인증 유저 검증 로직 추가
