### PR TITLE
[FEAT] [BE] 닉네임 유효성 검사 로직 및 테스트 코드 추가

### DIFF
--- a/src/main/java/com/ll/quizzle/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/quizzle/domain/member/entity/Member.java
@@ -1,18 +1,21 @@
 package com.ll.quizzle.domain.member.entity;
 
+import static com.ll.quizzle.global.exceptions.ErrorCode.*;
+
 import com.ll.quizzle.domain.member.type.Role;
 import com.ll.quizzle.global.jpa.entity.BaseEntity;
 import com.ll.quizzle.global.security.oauth2.entity.OAuth;
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 
 @Entity
 @Getter
@@ -66,11 +69,6 @@ public class Member extends BaseEntity {
         return this.role == Role.MEMBER;
     }
 
-    /**
-     * 포인트 증가
-     *
-     * @param amount 증가할 포인트 양 (양수)
-     */
     public void increasePoint(int amount) {
         if (amount <= 0) {
             POINT_INCREASE_AMOUNT_INVALID.throwServiceException();
@@ -78,47 +76,37 @@ public class Member extends BaseEntity {
         this.pointBalance += amount;
     }
 
-    /**
-     * 포인트 차감
-     *
-     * @param amount 차감할 포인트 양 (양수)
-     */
     public void decreasePoint(int amount) {
         if (amount <= 0) {
             POINT_DECREASE_AMOUNT_INVALID.throwServiceException();
         }
-
         if (this.pointBalance < amount) {
             POINT_NOT_ENOUGH.throwServiceException();
         }
-
         this.pointBalance -= amount;
     }
 
-
     public void updateExp(int newExp) {
         this.exp = newExp;
-        int calculatedLevel = newExp / 100;  // 100 EXP마다 레벨업
+        int calculatedLevel = newExp / 100;
         if (calculatedLevel > this.level) {
             this.level = calculatedLevel;
         }
     }
 
-
     public static Member create(String nickname, String email) {
         return Member.builder()
-                .nickname(nickname)
-                .email(email)
-                .level(0)
-                .role(Role.MEMBER)
-                .exp(0)
-                .profilePath("기본경로")
-                .pointBalance(0)
-                .build();
+            .nickname(nickname)
+            .email(email)
+            .level(0)
+            .role(Role.MEMBER)
+            .exp(0)
+            .profilePath("기본경로")
+            .pointBalance(0)
+            .build();
     }
 
-	public void changeNickname(String nickname) {
-		// Todo:닉네임 유효성 검사 또는 중복 검사 필요 시 여기에 추가
-		this.nickname = nickname;
-	}
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/ll/quizzle/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ll/quizzle/domain/member/repository/MemberRepository.java
@@ -1,13 +1,15 @@
 package com.ll.quizzle.domain.member.repository;
 
-import com.ll.quizzle.domain.member.entity.Member;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import com.ll.quizzle.domain.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String memberEmail);
 
     Optional<Member> findByNickname(String nickname);
 
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
@@ -188,13 +188,28 @@ public class MemberService {
 
 	@Transactional
 	public MemberProfileEditResponse updateProfile(Long memberId, String newNickname) {
-
 		Member member = rq.assertIsOwner(memberId);
 
+		validateNickname(newNickname);
 		member.changeNickname(newNickname);
 		pointService.applyPointPolicy(member, PointReason.NICKNAME_CHANGE);
-
+		memberRepository.save(member);
 		return MemberProfileEditResponse.from(member);
+	}
+
+	public void validateNickname(String nickname) {
+		if (nickname == null || nickname.trim().isEmpty()) {
+			NICKNAME_INVALID.throwServiceException();
+		}
+		if (nickname.length() < 2 || nickname.length() > 20) {
+			NICKNAME_LENGTH_INVALID.throwServiceException();
+		}
+		if (!nickname.matches("^[a-zA-Z0-9가-힣]+$")) {
+			NICKNAME_FORMAT_INVALID.throwServiceException();
+		}
+		if (memberRepository.existsByNickname(nickname)) {
+			NICKNAME_ALREADY_EXISTS.throwServiceException();
+		}
 	}
 
 }

--- a/src/main/java/com/ll/quizzle/domain/point/controller/PointController.java
+++ b/src/main/java/com/ll/quizzle/domain/point/controller/PointController.java
@@ -14,15 +14,19 @@ import com.ll.quizzle.domain.point.type.PointType;
 import com.ll.quizzle.global.response.RsData;
 import com.ll.quizzle.standard.page.dto.PageDto;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "PointController", description = "포인트 관련 API")
 @RequestMapping("/api/v1/members")
 public class PointController {
 
 	private final PointService pointService;
 
+	@Operation(summary = "포인트 히스토리 조회", description = "멤버 ID를 기반으로 포인트 히스토리를 조회합니다.")
 	@GetMapping("/{memberId}/points")
 	public RsData<PageDto<PointHistoryResponse>> getPointHistories(
 		@PathVariable("memberId") Long memberId,
@@ -34,5 +38,4 @@ public class PointController {
 		PageDto<PointHistoryResponse> result = pointService.getPointHistoriesWithPage(memberId, requestDto);
 		return RsData.success(HttpStatus.OK, result);
 	}
-
 }

--- a/src/main/java/com/ll/quizzle/domain/point/dto/response/PointHistoryResponse.java
+++ b/src/main/java/com/ll/quizzle/domain/point/dto/response/PointHistoryResponse.java
@@ -15,7 +15,7 @@ public record PointHistoryResponse(
 			point.getType().name(),
 			point.getAmount(),
 			point.getReason().getDescription(),
-			point.getCreateDate()
+			point.getOccurredAt()
 		);
 	}
 }

--- a/src/main/java/com/ll/quizzle/domain/point/entity/Point.java
+++ b/src/main/java/com/ll/quizzle/domain/point/entity/Point.java
@@ -1,16 +1,15 @@
 package com.ll.quizzle.domain.point.entity;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.point.type.PointReason;
 import com.ll.quizzle.domain.point.type.PointType;
-import com.ll.quizzle.global.jpa.entity.BaseTime;
+import com.ll.quizzle.global.jpa.entity.BaseEntity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Point extends BaseTime {
+public class Point extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
@@ -32,6 +31,9 @@ public class Point extends BaseTime {
 
 	@Enumerated(EnumType.STRING)
 	private PointReason reason;
+
+	@CreatedDate
+	private LocalDateTime occurredAt;
 
 	@Builder
 	public Point(Member member, int amount, PointType type, PointReason reason) {

--- a/src/main/java/com/ll/quizzle/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/ll/quizzle/domain/point/repository/PointRepository.java
@@ -10,7 +10,7 @@ import com.ll.quizzle.domain.point.type.PointType;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
 
-	Page<Point> findPageByMemberOrderByCreateDateDesc(Member member, Pageable pageable);
+	Page<Point> findPageByMemberAndTypeOrderByOccurredAtDesc(Member member, PointType type, Pageable pageable);
+	Page<Point> findPageByMemberOrderByOccurredAtDesc(Member member, Pageable pageable);
 
-	Page<Point> findPageByMemberAndTypeOrderByCreateDateDesc(Member member, PointType type, Pageable pageable);
 }

--- a/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
+++ b/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
@@ -38,16 +38,13 @@ public class PointService {
 
 		Pageable pageable = PageRequest.of(requestDto.page(), requestDto.size());
 
-		Page<Point> page;
-
-		if (requestDto.type() != PointType.ALL) {
-			page = pointRepository.findPageByMemberAndTypeOrderByCreateDateDesc(member, requestDto.type(), pageable);
-		} else {
-			page = pointRepository.findPageByMemberOrderByCreateDateDesc(member, pageable);
-		}
+		Page<Point> page = (requestDto.type() == PointType.ALL) ?
+			pointRepository.findPageByMemberOrderByOccurredAtDesc(member, pageable) :
+			pointRepository.findPageByMemberAndTypeOrderByOccurredAtDesc(member, requestDto.type(), pageable);
 
 		return new PageDto<>(page.map(PointHistoryResponse::from));
 	}
+
 
 	// 포인트 사용
 	public void usePoint(Member member, int amount, PointReason reason) {

--- a/src/main/java/com/ll/quizzle/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/quizzle/global/exceptions/ErrorCode.java
@@ -11,8 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public enum ErrorCode {
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
 
 	// point
 	POINT_INCREASE_AMOUNT_INVALID(HttpStatus.BAD_REQUEST, "증가 포인트는 0보다 커야 합니다."),
@@ -21,43 +21,49 @@ public enum ErrorCode {
 	INVALID_POINT_REASON(HttpStatus.BAD_REQUEST, "유효하지 않은 포인트 사유입니다."),
 	POINT_POLICY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "포인트 정책이 정의되지 않았습니다."),
 
-    // jwt
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "리프레시 토큰을 찾을 수 없습니다."),
-    REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
+	// jwt
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+	TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
+	REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "리프레시 토큰을 찾을 수 없습니다."),
+	REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
 	TOKEN_INFO_NOT_FOUND(HttpStatus.BAD_REQUEST, "토큰 정보가 없습니다."),
 
-    // member + oauth
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원이 존재하지 않습니다."),
-    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
-    OAUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 OAuth 정보를 찾을 수 없습니다."),
-    OAUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 로그인에 실패했습니다."),
+	// member + oauth
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원이 존재하지 않습니다."),
+	EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
+	OAUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 OAuth 정보를 찾을 수 없습니다."),
+	OAUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 로그인에 실패했습니다."),
 
-    // WebSocket
-    WEBSOCKET_COOKIE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "WebSocket 연결을 위한 쿠키가 없습니다."),
-    WEBSOCKET_ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "WebSocket 연결을 위한 액세스 토큰이 없습니다."),
-    WEBSOCKET_TOKEN_VALIDATION_FAILED(HttpStatus.UNAUTHORIZED, "WebSocket 토큰 검증에 실패했습니다."),
-    WEBSOCKET_INVALID_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "잘못된 WebSocket 요청 타입입니다."),
-    WEBSOCKET_UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 메시징 프로바이더입니다."),
+	// WebSocket
+	WEBSOCKET_COOKIE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "WebSocket 연결을 위한 쿠키가 없습니다."),
+	WEBSOCKET_ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "WebSocket 연결을 위한 액세스 토큰이 없습니다."),
+	WEBSOCKET_TOKEN_VALIDATION_FAILED(HttpStatus.UNAUTHORIZED, "WebSocket 토큰 검증에 실패했습니다."),
+	WEBSOCKET_INVALID_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "잘못된 WebSocket 요청 타입입니다."),
+	WEBSOCKET_UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 메시징 프로바이더입니다."),
 
-    // GameRoom
-    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
-    NOT_ROOM_OWNER(HttpStatus.FORBIDDEN, "방장만 이 작업을 수행할 수 있습니다."),
+	// GameRoom
+	ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
+	NOT_ROOM_OWNER(HttpStatus.FORBIDDEN, "방장만 이 작업을 수행할 수 있습니다."),
+
+	// nickname
+	NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "닉네임이 유효하지 않습니다."),
+	NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "닉네임은 2자 이상 20자 이하이어야 합니다."),
+	NICKNAME_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "닉네임은 영문, 숫자, 한글만 사용할 수 있습니다."),
+	NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
 
 	// Global
 	FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 	INVALID_PAGE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 페이지 요청입니다.");
 
-    private final HttpStatus httpStatus;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String message;
 
-    public ServiceException throwServiceException() {
-        throw new ServiceException(httpStatus, message);
-    }
+	public ServiceException throwServiceException() {
+		throw new ServiceException(httpStatus, message);
+	}
 
-    public ServiceException throwServiceException(Throwable cause) {
-        throw new ServiceException(httpStatus, message, cause);
-    }
+	public ServiceException throwServiceException(Throwable cause) {
+		throw new ServiceException(httpStatus, message, cause);
+	}
 }

--- a/src/test/java/com/ll/quizzle/domain/member/MemberProfileEditTest.java
+++ b/src/test/java/com/ll/quizzle/domain/member/MemberProfileEditTest.java
@@ -1,0 +1,102 @@
+package com.ll.quizzle.domain.member;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.quizzle.domain.member.entity.Member;
+import com.ll.quizzle.domain.member.repository.MemberRepository;
+import com.ll.quizzle.domain.member.service.AuthTokenService;
+import com.ll.quizzle.factory.TestMemberFactory;
+import com.ll.quizzle.global.jwt.dto.GeneratedToken;
+import com.ll.quizzle.global.security.oauth2.repository.OAuthRepository;
+
+import jakarta.servlet.http.Cookie;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class MemberProfileEditTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AuthTokenService authTokenService;
+
+    @Autowired
+    private OAuthRepository oauthRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Member member;
+    private Cookie accessTokenCookie;
+
+    @BeforeEach
+    void setUp() {
+        member = TestMemberFactory.createOAuthMember("테스트유저", "test@email.com", "google", "1234", memberRepository, oauthRepository);
+        GeneratedToken token = authTokenService.generateToken(member.getEmail(), member.getRole().name());
+        accessTokenCookie = new Cookie("access_token", token.accessToken());
+    }
+
+    @Test
+    @DisplayName("닉네임이 공백일 때")
+    void updateNickname_empty() throws Exception {
+        mockMvc.perform(patch("/api/v1/members/" + member.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(accessTokenCookie)
+                .content(objectMapper.writeValueAsString(Map.of("nickname", " "))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 2자 이상 20자 이하로 입력해주세요.")));
+    }
+
+    @Test
+    @DisplayName("닉네임이 너무 짧을 때")
+    void updateNickname_tooShort() throws Exception {
+        mockMvc.perform(patch("/api/v1/members/" + member.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(accessTokenCookie)
+                .content(objectMapper.writeValueAsString(Map.of("nickname", "A"))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 2자 이상 20자 이하로 입력해주세요.")));
+    }
+
+    @Test
+    @DisplayName("닉네임에 특수문자가 포함될 때")
+    void updateNickname_invalidFormat() throws Exception {
+        mockMvc.perform(patch("/api/v1/members/" + member.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(accessTokenCookie)
+                .content(objectMapper.writeValueAsString(Map.of("nickname", "Invalid@Nick"))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.msg").value("닉네임은 영문, 숫자, 한글만 사용할 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("중복된 닉네임일 때")
+    void updateNickname_duplicate() throws Exception {
+        TestMemberFactory.createOAuthMember("중복닉네임", "duplicate@email.com", "google", "5678", memberRepository, oauthRepository);
+        mockMvc.perform(patch("/api/v1/members/" + member.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(accessTokenCookie)
+                .content(objectMapper.writeValueAsString(Map.of("nickname", "중복닉네임"))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.msg").value("이미 존재하는 닉네임입니다."));
+    }
+}


### PR DESCRIPTION
## 📝Part
- [x] BE
- [ ] FE

<br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

<br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 🔎 작업 내용
### 닉네임 유효성 검사 로직 추가
- 닉네임 중복 여부를 확인하는 `existsByNickname` 메서드를 `MemberRepository`에 추가
- `MemberService`에 닉네임 유효성 검사 로직을 구현하여 중복, 길이, 형식 오류를 처리
- 닉네임 변경 시 포인트 부족 예외 처리 로직 추가

### 닉네임 유효성 검사 테스트 추가
- `MemberProfileEditTest` 클래스에 다양한 유효성 검사 케이스를 추가
  - 포인트 부족으로 닉네임 변경 실패할 때
  - 정상적인 닉네임 변경이 성공할 때
  - 닉네임이 공백일 때
  - 닉네임이 너무 짧을 때
  - 특수문자가 포함된 닉네임일 때
  - 중복 닉네임일 때

### 포인트 엔티티 리팩토링
- Point 엔티티에서 `BaseTime` 상속을 `BaseEntity` 상속으로 변경
- 포인트 발생 시간을 기록하기 위해 `occurredAt` 필드 추가

<br/>
