### PR TITLE
[REFACTOR] CookieUtil 사용하게 수정, swagger 문서 추가

### DIFF
--- a/src/main/java/com/ll/quizzle/domain/member/controller/OAuth2Controller.java
+++ b/src/main/java/com/ll/quizzle/domain/member/controller/OAuth2Controller.java
@@ -7,10 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,8 +30,8 @@ public class OAuth2Controller {
     @GetMapping("/oauth2/callback")
     @Operation(summary = "oauth 정보 확인용", description = "OAuth2 인증 정보 확인 API입니다. Status에 SUCCESS가 아닌 경우, 인증 실패로 간주합니다.")
     public RsData<OAuth2InfoResponse> callback(
-            @RequestParam String accessToken,
-            @RequestParam String refreshToken,
+            @CookieValue(value = "access_token", required = false) String accessToken,
+            @CookieValue(value = "refresh_token", required = false) String refreshToken,
             @RequestParam String status
     ) {
         return oAuth2Service.OAuthInfoToResponseData(accessToken, refreshToken, status);

--- a/src/main/java/com/ll/quizzle/domain/member/controller/OAuth2Controller.java
+++ b/src/main/java/com/ll/quizzle/domain/member/controller/OAuth2Controller.java
@@ -36,4 +36,15 @@ public class OAuth2Controller {
     ) {
         return oAuth2Service.OAuthInfoToResponseData(accessToken, refreshToken, status);
     }
+
+    @GetMapping("/no-use")
+    @Operation(summary = "소셜로그인 방법 (문서화를 위한, 사용하지 않는 api입니다.)", description = """
+            localhost:8080/oauth2/authorization/{provider} \n
+            provider : kakao, google \n
+            카카오, 구글 로그인 주소입니다.
+            """)
+    public void noUse() {
+        // 이 API는 사용되지 않음
+        // 실제로는 사용되지 않지만, Swagger 문서화 용도로 남겨둡니다.
+    }
 }

--- a/src/main/java/com/ll/quizzle/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/ll/quizzle/global/jwt/JwtAuthFilter.java
@@ -7,6 +7,7 @@ import com.ll.quizzle.domain.member.service.MemberService;
 import com.ll.quizzle.global.exceptions.ServiceException;
 import com.ll.quizzle.global.response.RsData;
 import com.ll.quizzle.global.security.oauth2.dto.SecurityUser;
+import com.ll.quizzle.standard.util.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -98,10 +99,14 @@ public class JwtAuthFilter extends OncePerRequestFilter implements Ordered {
                         RsData<String> refreshResult = memberService.refreshAccessToken(refreshToken);
                         if (refreshResult.isSuccess()) {
                             log.debug("새로운 Access Token 발급 성공");
-                            Cookie newAccessTokenCookie = new Cookie("access_token", refreshResult.getData());
-                            newAccessTokenCookie.setPath("/");
-                            newAccessTokenCookie.setHttpOnly(true);
-                            response.addCookie(newAccessTokenCookie);
+                            CookieUtil.addCookie(
+                                    response,
+                                    "access_token",
+                                    refreshResult.getData(),
+                                    86400,
+                                    true,
+                                    true
+                            );
 
                             String email = memberService.extractEmailIfValid(refreshResult.getData());
                             Member member = memberRepository.findByEmail(email)

--- a/src/main/java/com/ll/quizzle/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/ll/quizzle/global/jwt/JwtAuthFilter.java
@@ -143,7 +143,7 @@ public class JwtAuthFilter extends OncePerRequestFilter implements Ordered {
         String requestURI = request.getRequestURI();
 
         return requestURI.equals("/api/v1/members/refresh") ||
-                (requestURI.contains("/oauth2/callback") && request.getParameter("accessToken") == null) ||
+//                (requestURI.contains("/oauth2/callback") && request.getParameter("accessToken") == null) ||
                 requestURI.startsWith("/h2-console");
     }
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- JwtFilter - CookieUtil 사용
- ouath2 callback 메서드 - 파라미터값으로 받던 access, refresh token -> cookie 로 수정
- 소셜로그인방식 swagger에 문서 추가용으로 사용하지않는 noUse 메서드 추가