### PR TITLE
[FEAT][BE] prod 환경 initdata 생성

### DIFF
--- a/src/main/java/com/ll/quizzle/domain/avatar/repository/AvatarRepository.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/repository/AvatarRepository.java
@@ -13,5 +13,6 @@ public interface AvatarRepository extends JpaRepository<Avatar, Long> {
     List<Avatar> findByStatus(AvatarStatus status);
     List<Avatar> findByMemberAndStatus(Member member, AvatarStatus status);
     Optional<Avatar> findByFileName(String fileName);
+    boolean existsByFileName(String fileName);
 
 }

--- a/src/main/java/com/ll/quizzle/global/initdata/ProdInitData.java
+++ b/src/main/java/com/ll/quizzle/global/initdata/ProdInitData.java
@@ -1,0 +1,51 @@
+package com.ll.quizzle.global.initdata;
+
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.type.AvatarStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Profile("prod")
+@Configuration
+@RequiredArgsConstructor
+public class ProdInitData {
+
+    private final AvatarRepository avatarRepository;
+
+    @Bean
+    public ApplicationRunner prodInitDataRunner() {
+        return args -> initAvatars();
+    }
+
+    @Transactional
+    public void initAvatars() {
+        if (avatarRepository.existsByFileName("새콩이")) {
+            Avatar saekong = Avatar.builder()
+                .fileName("새콩이")
+                .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EA%B8%B0%EB%B3%B8+%EC%95%84%EB%B0%94%ED%83%80.png")
+                .price(0)
+                .status(AvatarStatus.OWNED)
+                .build();
+
+            avatarRepository.save(saekong);
+        }
+
+        if (avatarRepository.existsByFileName("안경쓴 새콩이")) {
+            Avatar nerdySaekong = Avatar.builder()
+                .fileName("안경쓴 새콩이")
+                .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EC%95%88%EA%B2%BD%EC%93%B4+%EC%83%88%EC%BD%A9%EC%9D%B4.png")
+                .price(300)
+                .status(AvatarStatus.AVAILABLE)
+                .build();
+
+            avatarRepository.save(nerdySaekong);
+        }
+    }
+}

--- a/src/main/java/com/ll/quizzle/standard/util/CookieUtil.java
+++ b/src/main/java/com/ll/quizzle/standard/util/CookieUtil.java
@@ -1,12 +1,12 @@
 package com.ll.quizzle.standard.util;
 
+import java.util.Optional;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-
-import java.util.Optional;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CookieUtil {
@@ -37,7 +37,7 @@ public class CookieUtil {
         cookie.setMaxAge(maxAge);
         cookie.setHttpOnly(isHttpOnly); // 자바스크립트에서 쿠키에 접근할 수 없도록 설정 (XSS 방지)
         cookie.setSecure(isSecure); // HTTPS에서만 쿠키를 전송하도록 설정 (CSRF 방지)
-        cookie.setAttribute("SameSite", "None"); // SameSite 속성 설정
+        cookie.setAttribute("SameSite", "Lax"); // SameSite 속성 설정
         response.addCookie(cookie);
     }
 


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[1] -->

## 📝Part
- [x] BE
- [ ] FE

<br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

<br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 🔎 작업 내용
- `prod` 프로필에서만 실행되는 아바타 초기화 기능 추가
- 새콩이(기본 아바타), 안경쓴 새콩이 아바타 2종만 DB에 삽입
- 이미 해당 이름의 아바타가 존재하는 경우 중복 생성 방지
