### PR TITLE
[REFACTOR][BE] 기본 아바타("새콩이") 지급 및 할당 로직 수정

### DIFF
--- a/src/main/java/com/ll/quizzle/domain/avatar/repository/AvatarRepository.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/repository/AvatarRepository.java
@@ -14,5 +14,5 @@ public interface AvatarRepository extends JpaRepository<Avatar, Long> {
     List<Avatar> findByMemberAndStatus(Member member, AvatarStatus status);
     Optional<Avatar> findByFileName(String fileName);
     boolean existsByFileName(String fileName);
-
+    boolean existsByMemberAndFileName(Member member, String fileName);
 }

--- a/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.ll.quizzle.domain.member.service;
 
+import static com.ll.quizzle.global.exceptions.ErrorCode.*;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -21,13 +23,6 @@ import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.point.service.PointService;
 import com.ll.quizzle.domain.point.type.PointReason;
-import static com.ll.quizzle.global.exceptions.ErrorCode.AVATAR_ALREADY_APPLIED;
-import static com.ll.quizzle.global.exceptions.ErrorCode.AVATAR_NOT_FOUND;
-import static com.ll.quizzle.global.exceptions.ErrorCode.AVATAR_NOT_OWNED;
-import static com.ll.quizzle.global.exceptions.ErrorCode.OAUTH_NOT_FOUND;
-import static com.ll.quizzle.global.exceptions.ErrorCode.TOKEN_INVALID;
-import static com.ll.quizzle.global.exceptions.ErrorCode.TOKEN_LOGGED_OUT;
-import static com.ll.quizzle.global.exceptions.ErrorCode.UNAUTHORIZED;
 import com.ll.quizzle.global.jwt.dto.GeneratedToken;
 import com.ll.quizzle.global.jwt.dto.JwtProperties;
 import com.ll.quizzle.global.request.Rq;
@@ -107,25 +102,33 @@ public class MemberService {
 
 	@Transactional
 	public void oAuth2Login(Member member, HttpServletResponse response) {
-		// 기본 아바타 없으면 할당
+		// 기본 아바타가 설정되어 있지 않다면
 		if (member.getAvatar() == null) {
-
-			Avatar defaultAvatar = avatarRepository.findAll().stream()
-				.filter(a -> a.getFileName().trim().equalsIgnoreCase("새콩이"))
-				.findFirst()
+			Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
 				.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
+			boolean alreadyOwned = avatarRepository.existsByMemberAndFileName(member, "새콩이");
+
+			if (!alreadyOwned) {
+				defaultAvatar.purchase(member);
+				avatarRepository.save(defaultAvatar);
+			}
+
+			// 구매(소유) 완료 후, 프로필에 아바타 할당
 			member.changeAvatar(defaultAvatar);
 			memberRepository.save(member);
 		}
 
+		// 로그인 토큰 발급
 		GeneratedToken tokens = authTokenService.generateToken(
 			member.getEmail(),
 			member.getUserRole()
 		);
 
+		// 쿠키 설정
 		addAuthCookies(response, tokens, member);
 	}
+
 
 	private void addAuthCookies(HttpServletResponse response, GeneratedToken tokens, Member member) {
 		// Access Token 쿠키

--- a/src/main/java/com/ll/quizzle/global/initdata/ProdInitData.java
+++ b/src/main/java/com/ll/quizzle/global/initdata/ProdInitData.java
@@ -31,7 +31,7 @@ public class ProdInitData {
                 .fileName("새콩이")
                 .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EA%B8%B0%EB%B3%B8+%EC%95%84%EB%B0%94%ED%83%80.png")
                 .price(0)
-                .status(AvatarStatus.OWNED)
+                .status(AvatarStatus.AVAILABLE)
                 .build();
 
             avatarRepository.save(saekong);


### PR DESCRIPTION
## 📝Part
- [x] BE
- [ ] FE

<br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

<br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

<br/>

## 🔎 작업 내용
- OAuth2 로그인 시, 기본 아바타("새콩이")가 자동 지급되도록 처리
- 이미 소유하고 있다면 중복 지급되지 않도록 방지
- 기본 아바타는 프로필 아바타로 자동 지정
- `AvatarRepository.existsByMemberAndFileName()` 메서드 추가
- `AvatarStatus.AVAILABLE`인 경우 `member = null` 유지, `OWNED`인 경우에만 `member` 연결되도록 보장
