### PR TITLE
[REFACTOR][BE]  Member 닉네임 기능 및 아바타 조회 개선

### DIFF
--- a/src/main/java/com/ll/quizzle/domain/avatar/entity/Avatar.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/entity/Avatar.java
@@ -20,23 +20,27 @@ public class Avatar extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member member;
+    private Member owner;
 
     @Enumerated(EnumType.STRING)
     private AvatarStatus status;
 
     @Builder
-    public Avatar(String fileName, String url, int price, Member member, AvatarStatus status) {
+    public Avatar(String fileName, String url, int price, Member owner, AvatarStatus status) {
         this.fileName = fileName;
         this.url = url;
         this.price = price;
-        this.member = member;
+        this.owner = owner;
         this.status = status;
     }
 
     public void purchase(Member member) {
-        this.member = member;
+        this.owner = member;
         this.status = AvatarStatus.OWNED;
+
+        if (!member.getOwnedAvatars().contains(this)) {
+            member.getOwnedAvatars().add(this);
+        }
     }
 
     public boolean isOwned() {

--- a/src/main/java/com/ll/quizzle/domain/avatar/repository/AvatarRepository.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/repository/AvatarRepository.java
@@ -11,8 +11,7 @@ import com.ll.quizzle.domain.member.entity.Member;
 
 public interface AvatarRepository extends JpaRepository<Avatar, Long> {
     List<Avatar> findByStatus(AvatarStatus status);
-    List<Avatar> findByMemberAndStatus(Member member, AvatarStatus status);
     Optional<Avatar> findByFileName(String fileName);
     boolean existsByFileName(String fileName);
-    boolean existsByMemberAndFileName(Member member, String fileName);
+    boolean existsByOwnerAndFileName(Member owner, String fileName);
 }

--- a/src/main/java/com/ll/quizzle/domain/avatar/service/AvatarService.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/service/AvatarService.java
@@ -2,7 +2,6 @@ package com.ll.quizzle.domain.avatar.service;
 
 import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -47,7 +46,6 @@ public class AvatarService {
         avatarRepository.save(avatar);
     }
 
-    // 아바타 구매 메서드
     @Transactional
     public void purchaseAvatar(Long memberId, Long avatarId) {
         Member member = rq.assertIsOwner(memberId);
@@ -59,14 +57,14 @@ public class AvatarService {
             throw AVATAR_ALREADY_OWNED.throwServiceException();
         }
 
-        // 포인트 차감 및 로그 기록
-        pointService.usePoint(member, avatar.getPrice(), PointReason.AVATAR_PURCHASE);
+        int price = avatar.getPrice();
+        if (price > 0) {
+            pointService.applyPointPolicy(member, -price, PointReason.AVATAR_PURCHASE);
+        }
 
-        // 아바타 구매 처리
         avatar.purchase(member);
         avatarRepository.save(avatar);
     }
-
 
     // 구매하지 않은 아바타 목록 조회
     public List<AvatarPurchaseResponse> getAvailableAvatars(Long memberId) {
@@ -79,17 +77,8 @@ public class AvatarService {
     // 소유한 아바타 목록 조회
     public List<AvatarPurchaseResponse> getOwnedAvatars(Long memberId) {
         Member member = rq.assertIsOwner(memberId);
-
-		List<Avatar> ownedAvatars = new ArrayList<>(avatarRepository.findByMemberAndStatus(member, AvatarStatus.OWNED));
-
-        Avatar currentAvatar = member.getAvatar();
-        if (currentAvatar != null && ownedAvatars.stream().noneMatch(a -> a.getId().equals(currentAvatar.getId()))) {
-            ownedAvatars.add(currentAvatar);
-        }
-
-        return ownedAvatars.stream()
+        return member.getOwnedAvatars().stream()
             .map(AvatarPurchaseResponse::from)
             .toList();
     }
-
 }

--- a/src/main/java/com/ll/quizzle/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/quizzle/domain/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,6 +43,13 @@ public class MemberController {
     public RsData<UserProfileResponse> getUserProfile(@PathVariable Long memberId) {
         Member member = memberService.findById(memberId).orElseThrow(MEMBER_NOT_FOUND::throwServiceException);
         return RsData.success(HttpStatus.OK, UserProfileResponse.of(member));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "닉네임으로 사용자 검색", description = "닉네임으로 회원을 검색합니다.")
+    public RsData<List<UserProfileResponse>> searchByNickname(@RequestParam String nickname) {
+        List<UserProfileResponse> responses = memberService.searchUserProfilesByNickname(nickname);
+        return RsData.success(HttpStatus.OK, responses);
     }
 
     @PatchMapping("/{memberId}/nickname")

--- a/src/main/java/com/ll/quizzle/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/quizzle/domain/member/entity/Member.java
@@ -2,11 +2,13 @@ package com.ll.quizzle.domain.member.entity;
 
 import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.ll.quizzle.domain.avatar.entity.Avatar;
 import com.ll.quizzle.domain.member.type.Role;
 import com.ll.quizzle.global.jpa.entity.BaseTime;
 import com.ll.quizzle.global.security.oauth2.entity.OAuth;
-import jakarta.persistence.*;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -16,19 +18,19 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static com.ll.quizzle.global.exceptions.ErrorCode.*;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTime {
-    @Column(nullable = false)
+
+    @Column(nullable = false, unique = true)
     private String nickname;
 
     @Column(nullable = false)
@@ -47,6 +49,9 @@ public class Member extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "avatar_id")
     private Avatar avatar;
+
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Avatar> ownedAvatars = new ArrayList<>();
 
     @Column(nullable = false)
     private int pointBalance;

--- a/src/main/java/com/ll/quizzle/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ll/quizzle/domain/member/repository/MemberRepository.java
@@ -10,8 +10,10 @@ import com.ll.quizzle.domain.member.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String memberEmail);
     Optional<Member> findById(Long id);
+    List<Member> findByNicknameContainingIgnoreCase(String keyword);
+
 
     boolean existsByNickname(String nickname);
-    
+
     List<Member> findAllByOrderByExpDesc();
 }

--- a/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
@@ -23,6 +23,7 @@ import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.point.service.PointService;
 import com.ll.quizzle.domain.point.type.PointReason;
+import com.ll.quizzle.global.exceptions.ErrorCode;
 import com.ll.quizzle.global.jwt.dto.GeneratedToken;
 import com.ll.quizzle.global.jwt.dto.JwtProperties;
 import com.ll.quizzle.global.request.Rq;
@@ -102,36 +103,30 @@ public class MemberService {
 
 	@Transactional
 	public void oAuth2Login(Member member, HttpServletResponse response) {
-		// 기본 아바타가 설정되어 있지 않다면
 		if (member.getAvatar() == null) {
 			Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
 				.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
-			boolean alreadyOwned = avatarRepository.existsByMemberAndFileName(member, "새콩이");
+			boolean alreadyOwned = avatarRepository.existsByOwnerAndFileName(member, "새콩이");
 
 			if (!alreadyOwned) {
 				defaultAvatar.purchase(member);
 				avatarRepository.save(defaultAvatar);
 			}
 
-			// 구매(소유) 완료 후, 프로필에 아바타 할당
 			member.changeAvatar(defaultAvatar);
 			memberRepository.save(member);
 		}
 
-		// 로그인 토큰 발급
 		GeneratedToken tokens = authTokenService.generateToken(
 			member.getEmail(),
 			member.getUserRole()
 		);
 
-		// 쿠키 설정
 		addAuthCookies(response, tokens, member);
 	}
 
-
 	private void addAuthCookies(HttpServletResponse response, GeneratedToken tokens, Member member) {
-		// Access Token 쿠키
 		CookieUtil.addCookie(
 			response,
 			"access_token",
@@ -141,7 +136,6 @@ public class MemberService {
 			true
 		);
 
-		// Refresh Token 쿠키
 		CookieUtil.addCookie(
 			response,
 			"refresh_token",
@@ -151,7 +145,6 @@ public class MemberService {
 			true
 		);
 
-		// Role 쿠키
 		Map<String, Object> roleData = new HashMap<>();
 		roleData.put("role", member.getUserRole());
 
@@ -180,7 +173,6 @@ public class MemberService {
 			}
 		}
 
-		// 액세스 토큰이 만료되었다면 리프레시 토큰으로 처리
 		if (accessToken == null && refreshToken != null) {
 			RsData<String> refreshResult = refreshAccessToken(refreshToken);
 			if (refreshResult.isSuccess()) {
@@ -194,7 +186,6 @@ public class MemberService {
 
 		String email = authTokenService.getEmail(accessToken);
 
-		// Redis에서 토큰 무효화
 		redisTemplate.opsForValue().set(
 			LOGOUT_PREFIX + accessToken,
 			email,
@@ -202,7 +193,6 @@ public class MemberService {
 			TimeUnit.MILLISECONDS
 		);
 
-		// Refresh 토큰 삭제
 		refreshTokenService.removeRefreshToken(email);
 
 		CookieUtil.deleteCookie(request, response, "access_token");
@@ -214,6 +204,10 @@ public class MemberService {
 	@Transactional
 	public MemberProfileEditResponse editNickname(Long memberId, String newNickname) {
 		Member member = rq.assertIsOwner(memberId);
+
+		if (memberRepository.existsByNickname(newNickname)) {
+			ErrorCode.NICKNAME_ALREADY_EXISTS.throwServiceException();
+		}
 
 		boolean isFirstNicknameSet = member.getNickname().startsWith("GUEST-");
 
@@ -233,7 +227,7 @@ public class MemberService {
 		Avatar avatar = avatarRepository.findById(avatarId)
 			.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
-		if (!avatar.isOwned() || !avatar.getMember().getId().equals(memberId)) {
+		if (!avatar.isOwned() || !avatar.getOwner().getId().equals(memberId)) {
 			throw AVATAR_NOT_OWNED.throwServiceException();
 		}
 
@@ -257,5 +251,4 @@ public class MemberService {
 			.map(MemberRankingResponse::of)
 			.collect(Collectors.toList());
 	}
-
 }

--- a/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
@@ -19,6 +19,7 @@ import com.ll.quizzle.domain.avatar.entity.Avatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
 import com.ll.quizzle.domain.member.dto.response.MemberProfileEditResponse;
 import com.ll.quizzle.domain.member.dto.response.MemberRankingResponse;
+import com.ll.quizzle.domain.member.dto.response.UserProfileResponse;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.point.service.PointService;
@@ -66,6 +67,14 @@ public class MemberService {
 	public Optional<Member> findByEmail(String email) {
 		return memberRepository.findByEmail(email);
 	}
+
+	@Transactional(readOnly = true)
+	public List<UserProfileResponse> searchUserProfilesByNickname(String nickname) {
+		return memberRepository.findByNicknameContainingIgnoreCase(nickname).stream()
+			.map(UserProfileResponse::of)
+			.toList();
+	}
+
 
 	public String generateRefreshToken(String email) {
 		return refreshTokenService.generateRefreshToken(email);

--- a/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
+++ b/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
@@ -74,4 +74,17 @@ public class PointService {
 			usePoint(member, -amount, reason);
 		}
 	}
+
+	public void applyPointPolicy(Member member, int customAmount, PointReason reason) {
+		if (customAmount == 0) {
+			throw POINT_POLICY_NOT_FOUND.throwServiceException();
+		}
+
+		if (customAmount > 0) {
+			gainPoint(member, customAmount, reason);
+		} else {
+			usePoint(member, -customAmount, reason);
+		}
+	}
+
 }

--- a/src/main/java/com/ll/quizzle/global/initdata/BaseInitData.java
+++ b/src/main/java/com/ll/quizzle/global/initdata/BaseInitData.java
@@ -106,7 +106,7 @@ public class BaseInitData {
             .fileName("새콩이")
             .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EA%B8%B0%EB%B3%B8+%EC%95%84%EB%B0%94%ED%83%80.png")
             .price(0)
-            .status(AvatarStatus.OWNED)
+            .status(AvatarStatus.AVAILABLE)
             .build();
 
         Avatar nerdySaekong = Avatar.builder()

--- a/src/main/java/com/ll/quizzle/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/quizzle/global/security/oauth2/CustomOAuth2UserService.java
@@ -97,7 +97,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             oAuthRepository.save(OAuth.create(member, registrationId, oauthId));
 
-            boolean alreadyOwned = avatarRepository.existsByMemberAndFileName(member, "새콩이");
+            boolean alreadyOwned = avatarRepository.existsByOwnerAndFileName(member, "새콩이");
             if (!alreadyOwned) {
                 defaultAvatar.purchase(member);
                 avatarRepository.save(defaultAvatar);

--- a/src/main/java/com/ll/quizzle/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/quizzle/global/security/oauth2/CustomOAuth2UserService.java
@@ -85,20 +85,28 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (existingMember.isPresent()) {
             member = existingMember.get();
         } else {
-            // 기본 아바타 조회
             Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
                 .orElseThrow(ErrorCode.AVATAR_NOT_FOUND::throwServiceException);
 
-            // 새로운 사용자 생성 (기본 아바타 포함)
             member = Member.create(
                 "GUEST-" + UUID.randomUUID().toString().substring(0, 6),
                 email,
-                defaultAvatar
+                null
             );
             memberRepository.save(member);
 
             oAuthRepository.save(OAuth.create(member, registrationId, oauthId));
+
+            boolean alreadyOwned = avatarRepository.existsByMemberAndFileName(member, "새콩이");
+            if (!alreadyOwned) {
+                defaultAvatar.purchase(member);
+                avatarRepository.save(defaultAvatar);
+            }
+
+            member.changeAvatar(defaultAvatar);
+            memberRepository.save(member);
         }
+
 
         return new SecurityUser(
             email,

--- a/src/test/java/com/ll/quizzle/domain/avatar/AvatarControllerTest.java
+++ b/src/test/java/com/ll/quizzle/domain/avatar/AvatarControllerTest.java
@@ -48,10 +48,12 @@ class AvatarControllerTest {
 	private Member member;
 	private Cookie accessTokenCookie;
 	private Avatar availableAvatar;
+	private Avatar defaultAvatar;
+
 
 	@BeforeEach
 	void setUp() {
-		Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
+		defaultAvatar = avatarRepository.findByFileName("새콩이")
 			.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
 		member = TestMemberFactory.createOAuthMember(
@@ -107,7 +109,13 @@ class AvatarControllerTest {
 	@Test
 	@DisplayName("소유한 아바타 목록 조회 성공")
 	void getOwnedAvatars_success() throws Exception {
-		// 미리 구매한 아바타 등록
+		// 기본 아바타 소유 처리
+		defaultAvatar = avatarRepository.findByFileName("새콩이")
+			.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
+		defaultAvatar.purchase(member);
+		avatarRepository.save(defaultAvatar);
+
+		// 추가 아바타 소유 처리
 		availableAvatar.purchase(member);
 		avatarRepository.save(availableAvatar);
 
@@ -116,8 +124,12 @@ class AvatarControllerTest {
 				.cookie(accessTokenCookie))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data").isArray())
-			.andExpect(jsonPath("$.data.length()").value(2));
+			.andExpect(jsonPath("$.data.length()").value(2))
+			.andExpect(jsonPath("$.data[*].id").value(org.hamcrest.Matchers.containsInAnyOrder(
+				defaultAvatar.getId().intValue(), availableAvatar.getId().intValue()
+			)));
 	}
+
 
 	@Test
 	@DisplayName("구매 가능한 아바타 목록 조회 성공")

--- a/src/test/java/com/ll/quizzle/domain/member/MemberAvatarEditTest.java
+++ b/src/test/java/com/ll/quizzle/domain/member/MemberAvatarEditTest.java
@@ -63,7 +63,7 @@ class MemberAvatarEditTest {
 			.fileName("소유한 아바타")
 			.url("https://url.com/owned.png")
 			.price(0)
-			.member(member)
+			.owner(member)
 			.status(com.ll.quizzle.domain.avatar.type.AvatarStatus.OWNED)
 			.build();
 		avatarRepository.save(ownedAvatar);

--- a/src/test/java/com/ll/quizzle/domain/member/MemberNicknameEditTest.java
+++ b/src/test/java/com/ll/quizzle/domain/member/MemberNicknameEditTest.java
@@ -105,7 +105,7 @@ class MemberNicknameEditTest {
                 .cookie(accessTokenCookie)
                 .content(objectMapper.writeValueAsString(Map.of("nickname", " "))))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 2자 이상 20자 이하로 입력해주세요.")));
+            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임이 유효하지 않습니다.")));
     }
 
     @Test
@@ -116,7 +116,7 @@ class MemberNicknameEditTest {
                 .cookie(accessTokenCookie)
                 .content(objectMapper.writeValueAsString(Map.of("nickname", "A"))))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 2자 이상 20자 이하로 입력해주세요.")));
+            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 2자 이상 20자 이하이어야 합니다.")));
     }
 
     @Test
@@ -127,7 +127,8 @@ class MemberNicknameEditTest {
                 .cookie(accessTokenCookie)
                 .content(objectMapper.writeValueAsString(Map.of("nickname", "Invalid@Nick"))))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.msg").value("닉네임은 영문, 숫자, 한글만 사용할 수 있습니다."));
+            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 영문, 숫자, 한글만 사용할 수 있습니다.")));
+
     }
 
     @Test


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[1] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- Member의 소유한 아바타 목록 조회 방식 개선 (`member.getAvatars()` 활용)
- 닉네임 중복 검증 로직 추가 (`NICKNAME_ALREADY_EXISTS` 예외 적용)
- 닉네임으로 사용자 검색 API 추가 (`GET /api/v1/members/search`)
- 관련 컨트롤러 및 서비스 리팩토링
- 중복 닉네임 및 포맷 관련 테스트 코드 추가 및 보완