### PR TITLE
[REFACTOR][BE] Avatar 소유 구조 분리 및 관련 비즈니스 로직 리팩토링

### DIFF
--- a/src/main/java/com/ll/quizzle/domain/avatar/dto/response/AvatarPurchaseResponse.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/dto/response/AvatarPurchaseResponse.java
@@ -1,6 +1,7 @@
 package com.ll.quizzle.domain.avatar.dto.response;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
 import com.ll.quizzle.domain.avatar.type.AvatarStatus;
 
 public record AvatarPurchaseResponse(
@@ -10,12 +11,25 @@ public record AvatarPurchaseResponse(
     AvatarStatus status,
     String url
 ) {
+    // 소유한 아바타 응답 (OwnedAvatar 기반)
+    public static AvatarPurchaseResponse from(OwnedAvatar ownedAvatar) {
+        Avatar avatar = ownedAvatar.getAvatar();
+        return new AvatarPurchaseResponse(
+            avatar.getId(),
+            avatar.getFileName(),
+            avatar.getPrice(),
+            ownedAvatar.getStatus(),
+            avatar.getUrl()
+        );
+    }
+
+    // 구매 가능한 아바타 응답 (Avatar 기반)
     public static AvatarPurchaseResponse from(Avatar avatar) {
         return new AvatarPurchaseResponse(
             avatar.getId(),
             avatar.getFileName(),
             avatar.getPrice(),
-            avatar.getStatus(),
+            null, // 상태 없음
             avatar.getUrl()
         );
     }

--- a/src/main/java/com/ll/quizzle/domain/avatar/entity/Avatar.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/entity/Avatar.java
@@ -18,28 +18,12 @@ public class Avatar extends BaseEntity {
     private String url;
     private int price;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    @Enumerated(EnumType.STRING)
-    private AvatarStatus status;
-
     @Builder
-    public Avatar(String fileName, String url, int price, Member member, AvatarStatus status) {
+    public Avatar(String fileName, String url, int price) {
         this.fileName = fileName;
         this.url = url;
         this.price = price;
-        this.member = member;
-        this.status = status;
     }
 
-    public void purchase(Member member) {
-        this.member = member;
-        this.status = AvatarStatus.OWNED;
-    }
 
-    public boolean isOwned() {
-        return this.status == AvatarStatus.OWNED;
-    }
 }

--- a/src/main/java/com/ll/quizzle/domain/avatar/entity/OwnedAvatar.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/entity/OwnedAvatar.java
@@ -1,0 +1,46 @@
+package com.ll.quizzle.domain.avatar.entity;
+
+import com.ll.quizzle.domain.avatar.type.AvatarStatus;
+import com.ll.quizzle.domain.member.entity.Member;
+import com.ll.quizzle.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OwnedAvatar extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "avatar_id")
+    private Avatar avatar;
+
+    @Enumerated(EnumType.STRING)
+    private AvatarStatus status;
+
+    @Builder
+    public OwnedAvatar(Member member, Avatar avatar, AvatarStatus status) {
+        this.member = member;
+        this.avatar = avatar;
+        this.status = status;
+    }
+
+    public static OwnedAvatar create(Member member, Avatar avatar) {
+        return OwnedAvatar.builder()
+            .member(member)
+            .avatar(avatar)
+            .status(AvatarStatus.OWNED)
+            .build();
+    }
+
+    public boolean isOwned() {
+        return this.status == AvatarStatus.OWNED;
+    }
+}

--- a/src/main/java/com/ll/quizzle/domain/avatar/repository/AvatarRepository.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/repository/AvatarRepository.java
@@ -1,18 +1,12 @@
 package com.ll.quizzle.domain.avatar.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
-import com.ll.quizzle.domain.avatar.type.AvatarStatus;
-import com.ll.quizzle.domain.member.entity.Member;
 
 public interface AvatarRepository extends JpaRepository<Avatar, Long> {
-    List<Avatar> findByStatus(AvatarStatus status);
-    List<Avatar> findByMemberAndStatus(Member member, AvatarStatus status);
     Optional<Avatar> findByFileName(String fileName);
     boolean existsByFileName(String fileName);
-    boolean existsByMemberAndFileName(Member member, String fileName);
 }

--- a/src/main/java/com/ll/quizzle/domain/avatar/repository/OwnedAvatarRepository.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/repository/OwnedAvatarRepository.java
@@ -1,0 +1,22 @@
+package com.ll.quizzle.domain.avatar.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
+import com.ll.quizzle.domain.member.entity.Member;
+
+public interface OwnedAvatarRepository extends JpaRepository<OwnedAvatar, Long> {
+
+    // 특정 사용자가 해당 아바타를 소유하고 있는지 여부 확인
+    boolean existsByMemberAndAvatar(Member member, Avatar avatar);
+
+    // 특정 유저가 소유한 특정 아바타 조회 (선택적으로 활용 가능)
+    Optional<OwnedAvatar> findByMemberAndAvatar(Member member, Avatar avatar);
+
+    List<OwnedAvatar> findAllByMember(Member member);
+
+}

--- a/src/main/java/com/ll/quizzle/domain/avatar/service/AvatarService.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/service/AvatarService.java
@@ -2,7 +2,6 @@ package com.ll.quizzle.domain.avatar.service;
 
 import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -11,7 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ll.quizzle.domain.avatar.dto.request.AvatarCreateRequest;
 import com.ll.quizzle.domain.avatar.dto.response.AvatarPurchaseResponse;
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
 import com.ll.quizzle.domain.avatar.type.AvatarStatus;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.point.service.PointService;
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class AvatarService {
 
     private final AvatarRepository avatarRepository;
+    private final OwnedAvatarRepository ownedAvatarRepository;
     private final PointService pointService;
     private final Rq rq;
 
@@ -41,13 +43,11 @@ public class AvatarService {
             .fileName(request.fileName())
             .url(request.url())
             .price(request.price())
-            .status(AvatarStatus.AVAILABLE)
             .build();
 
         avatarRepository.save(avatar);
     }
 
-    // 아바타 구매 메서드
     @Transactional
     public void purchaseAvatar(Long memberId, Long avatarId) {
         Member member = rq.assertIsOwner(memberId);
@@ -55,23 +55,31 @@ public class AvatarService {
         Avatar avatar = avatarRepository.findById(avatarId)
             .orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
-        if (avatar.isOwned()) {
+        if (member.hasAvatar(avatar)) {
             throw AVATAR_ALREADY_OWNED.throwServiceException();
         }
 
-        // 포인트 차감 및 로그 기록
-        pointService.usePoint(member, avatar.getPrice(), PointReason.AVATAR_PURCHASE);
+        int price = avatar.getPrice();
+        if (price > 0) {
+            pointService.applyPointPolicy(member, -price, PointReason.AVATAR_PURCHASE);
+        }
 
-        // 아바타 구매 처리
-        avatar.purchase(member);
-        avatarRepository.save(avatar);
+        OwnedAvatar ownedAvatar = OwnedAvatar.create(member, avatar);
+        member.addOwnedAvatar(ownedAvatar);
+        ownedAvatarRepository.save(ownedAvatar);
     }
-
 
     // 구매하지 않은 아바타 목록 조회
     public List<AvatarPurchaseResponse> getAvailableAvatars(Long memberId) {
-        rq.assertIsOwner(memberId);
-        return avatarRepository.findByStatus(AvatarStatus.AVAILABLE).stream()
+        Member member = rq.assertIsOwner(memberId);
+
+        List<Avatar> allAvatars = avatarRepository.findAll();
+        List<Long> ownedAvatarIds = member.getOwnedAvatars().stream()
+            .map(owned -> owned.getAvatar().getId())
+            .toList();
+
+        return allAvatars.stream()
+            .filter(avatar -> !ownedAvatarIds.contains(avatar.getId()))
             .map(AvatarPurchaseResponse::from)
             .toList();
     }
@@ -80,16 +88,10 @@ public class AvatarService {
     public List<AvatarPurchaseResponse> getOwnedAvatars(Long memberId) {
         Member member = rq.assertIsOwner(memberId);
 
-		List<Avatar> ownedAvatars = new ArrayList<>(avatarRepository.findByMemberAndStatus(member, AvatarStatus.OWNED));
-
-        Avatar currentAvatar = member.getAvatar();
-        if (currentAvatar != null && ownedAvatars.stream().noneMatch(a -> a.getId().equals(currentAvatar.getId()))) {
-            ownedAvatars.add(currentAvatar);
-        }
+        List<OwnedAvatar> ownedAvatars = ownedAvatarRepository.findAllByMember(member);
 
         return ownedAvatars.stream()
             .map(AvatarPurchaseResponse::from)
             .toList();
     }
-
 }

--- a/src/main/java/com/ll/quizzle/domain/avatar/type/AvatarTemplate.java
+++ b/src/main/java/com/ll/quizzle/domain/avatar/type/AvatarTemplate.java
@@ -1,0 +1,26 @@
+package com.ll.quizzle.domain.avatar.type;
+
+import com.ll.quizzle.domain.avatar.entity.Avatar;
+
+public enum AvatarTemplate {
+    DEFAULT("새콩이", "https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EA%B8%B0%EB%B3%B8+%EC%95%84%EB%B0%94%ED%83%80.png", 0),
+    NERDY("안경쓴 새콩이", "https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EC%95%88%EA%B2%BD%EC%93%B4+%EC%83%88%EC%BD%A9%EC%9D%B4.png", 300);
+
+    public final String fileName;
+    public final String url;
+    public final int price;
+
+    AvatarTemplate(String fileName, String url, int price) {
+        this.fileName = fileName;
+        this.url = url;
+        this.price = price;
+    }
+
+    public Avatar toEntity() {
+        return Avatar.builder()
+            .fileName(fileName)
+            .url(url)
+            .price(price)
+            .build();
+    }
+}

--- a/src/main/java/com/ll/quizzle/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/quizzle/domain/member/entity/Member.java
@@ -2,11 +2,14 @@ package com.ll.quizzle.domain.member.entity;
 
 import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
 import com.ll.quizzle.domain.member.type.Role;
 import com.ll.quizzle.global.jpa.entity.BaseTime;
 import com.ll.quizzle.global.security.oauth2.entity.OAuth;
-import jakarta.persistence.*;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -16,19 +19,19 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static com.ll.quizzle.global.exceptions.ErrorCode.*;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTime {
-    @Column(nullable = false)
+
+    @Column(nullable = false, unique = true)
     private String nickname;
 
     @Column(nullable = false)
@@ -48,6 +51,9 @@ public class Member extends BaseTime {
     @JoinColumn(name = "avatar_id")
     private Avatar avatar;
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OwnedAvatar> ownedAvatars = new ArrayList<>();
+
     @Column(nullable = false)
     private int pointBalance;
 
@@ -65,6 +71,17 @@ public class Member extends BaseTime {
         this.avatar = avatar;
     }
 
+    public static Member create(String nickname, String email, Avatar avatar) {
+        return Member.builder()
+            .nickname(nickname)
+            .email(email)
+            .level(1)
+            .role(Role.MEMBER)
+            .exp(0)
+            .pointBalance(0)
+            .avatar(avatar)
+            .build();
+    }
 
     public String getUserRole() {
         return this.role.name();
@@ -97,24 +114,21 @@ public class Member extends BaseTime {
         }
     }
 
-    public static Member create(String nickname, String email, Avatar avatar) {
-        return Member.builder()
-            .nickname(nickname)
-            .email(email)
-            .level(1)
-            .role(Role.MEMBER)
-            .exp(0)
-            .pointBalance(0)
-            .avatar(avatar)
-            .build();
-    }
-
     public void changeNickname(String nickname) {
         this.nickname = nickname;
     }
 
     public void changeAvatar(Avatar avatar) {
         this.avatar = avatar;
+    }
+
+    public void addOwnedAvatar(OwnedAvatar ownedAvatar) {
+        this.ownedAvatars.add(ownedAvatar);
+    }
+
+    public boolean hasAvatar(Avatar avatar) {
+        return ownedAvatars.stream()
+            .anyMatch(owned -> owned.getAvatar().getId().equals(avatar.getId()));
     }
 
     public void changeRole(Role newRole) {

--- a/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/quizzle/domain/member/service/MemberService.java
@@ -1,7 +1,25 @@
 package com.ll.quizzle.domain.member.service;
 
+import static com.ll.quizzle.global.exceptions.ErrorCode.*;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
+import com.ll.quizzle.domain.avatar.type.AvatarTemplate;
 import com.ll.quizzle.domain.member.dto.response.MemberProfileEditResponse;
 import com.ll.quizzle.domain.member.dto.response.MemberRankingResponse;
 import com.ll.quizzle.domain.member.dto.response.UserProfileResponse;
@@ -17,30 +35,18 @@ import com.ll.quizzle.global.response.RsData;
 import com.ll.quizzle.global.security.oauth2.repository.OAuthRepository;
 import com.ll.quizzle.standard.util.CookieUtil;
 import com.ll.quizzle.standard.util.Ut;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 	private final MemberRepository memberRepository;
 	private final AvatarRepository avatarRepository;
+	private final OwnedAvatarRepository ownedAvatarRepository;
 	private final PointService pointService;
 	private final OAuthRepository oAuthRepository;
 	private final RefreshTokenService refreshTokenService;
@@ -72,6 +78,7 @@ public class MemberService {
 			.map(UserProfileResponse::of)
 			.toList();
 	}
+
 
 	public String generateRefreshToken(String email) {
 		return refreshTokenService.generateRefreshToken(email);
@@ -109,36 +116,32 @@ public class MemberService {
 
 	@Transactional
 	public void oAuth2Login(Member member, HttpServletResponse response) {
-		// 기본 아바타가 설정되어 있지 않다면
 		if (member.getAvatar() == null) {
-			Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
+			Avatar defaultAvatar = avatarRepository.findByFileName(AvatarTemplate.DEFAULT.fileName)
 				.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
-			boolean alreadyOwned = avatarRepository.existsByMemberAndFileName(member, "새콩이");
+			boolean alreadyOwned = member.hasAvatar(defaultAvatar);
 
 			if (!alreadyOwned) {
-				defaultAvatar.purchase(member);
-				avatarRepository.save(defaultAvatar);
+				OwnedAvatar ownedAvatar = OwnedAvatar.create(member, defaultAvatar);
+				member.addOwnedAvatar(ownedAvatar);
+				ownedAvatarRepository.save(ownedAvatar);
 			}
 
-			// 구매(소유) 완료 후, 프로필에 아바타 할당
 			member.changeAvatar(defaultAvatar);
 			memberRepository.save(member);
 		}
 
-		// 로그인 토큰 발급
 		GeneratedToken tokens = authTokenService.generateToken(
 			member.getEmail(),
 			member.getUserRole()
 		);
 
-		// 쿠키 설정
 		addAuthCookies(response, tokens, member);
 	}
 
 
 	private void addAuthCookies(HttpServletResponse response, GeneratedToken tokens, Member member) {
-		// Access Token 쿠키
 		CookieUtil.addCookie(
 			response,
 			"access_token",
@@ -148,7 +151,6 @@ public class MemberService {
 			true
 		);
 
-		// Refresh Token 쿠키
 		CookieUtil.addCookie(
 			response,
 			"refresh_token",
@@ -158,7 +160,6 @@ public class MemberService {
 			true
 		);
 
-		// Role 쿠키
 		Map<String, Object> roleData = new HashMap<>();
 		roleData.put("role", member.getUserRole());
 
@@ -187,7 +188,6 @@ public class MemberService {
 			}
 		}
 
-		// 액세스 토큰이 만료되었다면 리프레시 토큰으로 처리
 		if (accessToken == null && refreshToken != null) {
 			RsData<String> refreshResult = refreshAccessToken(refreshToken);
 			if (refreshResult.isSuccess()) {
@@ -201,7 +201,6 @@ public class MemberService {
 
 		String email = authTokenService.getEmail(accessToken);
 
-		// Redis에서 토큰 무효화
 		redisTemplate.opsForValue().set(
 			LOGOUT_PREFIX + accessToken,
 			email,
@@ -209,14 +208,12 @@ public class MemberService {
 			TimeUnit.MILLISECONDS
 		);
 
-		// Refresh 토큰 삭제
 		refreshTokenService.removeRefreshToken(email);
 
 		CookieUtil.deleteCookie(request, response, "access_token");
 		CookieUtil.deleteCookie(request, response, "refresh_token");
 		CookieUtil.deleteCookie(request, response, "role");
 		CookieUtil.deleteCookie(request, response, "oauth2_auth_request");
-		CookieUtil.deleteCookie(request, response, "JSESSIONID");
 	}
 
 	@Transactional
@@ -245,7 +242,7 @@ public class MemberService {
 		Avatar avatar = avatarRepository.findById(avatarId)
 			.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
-		if (!avatar.isOwned() || !avatar.getMember().getId().equals(memberId)) {
+		if (!member.hasAvatar(avatar)) {
 			throw AVATAR_NOT_OWNED.throwServiceException();
 		}
 
@@ -256,6 +253,7 @@ public class MemberService {
 		member.changeAvatar(avatar);
 		memberRepository.save(member);
 	}
+
 
 	@Transactional(readOnly = true)
 	public List<Member> getRankingByExp() {
@@ -269,5 +267,4 @@ public class MemberService {
 			.map(MemberRankingResponse::of)
 			.collect(Collectors.toList());
 	}
-
 }

--- a/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
+++ b/src/main/java/com/ll/quizzle/domain/point/service/PointService.java
@@ -74,4 +74,16 @@ public class PointService {
 			usePoint(member, -amount, reason);
 		}
 	}
+
+	public void applyPointPolicy(Member member, int customAmount, PointReason reason) {
+		if (customAmount == 0) {
+			throw POINT_POLICY_NOT_FOUND.throwServiceException();
+		}
+
+		if (customAmount > 0) {
+			gainPoint(member, customAmount, reason);
+		} else {
+			usePoint(member, -customAmount, reason);
+		}
+	}
 }

--- a/src/main/java/com/ll/quizzle/global/initdata/BaseInitData.java
+++ b/src/main/java/com/ll/quizzle/global/initdata/BaseInitData.java
@@ -11,8 +11,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
-import com.ll.quizzle.domain.avatar.type.AvatarStatus;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
+import com.ll.quizzle.domain.avatar.type.AvatarTemplate;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.member.type.Role;
@@ -29,6 +31,7 @@ public class BaseInitData {
     private final MemberRepository memberRepository;
     private final OAuthRepository oAuthRepository;
     private final AvatarRepository avatarRepository;
+    private final OwnedAvatarRepository ownedAvatarRepository;
     private final SystemService systemService;
 
     @Autowired
@@ -53,7 +56,6 @@ public class BaseInitData {
         Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
             .orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
-
         for (int i = 1; i <= 10; i++) {
             String nickname = "test" + i;
             String email = "test" + i + "@email.com";
@@ -61,63 +63,53 @@ public class BaseInitData {
 
             Member member = Member.create(nickname, email, defaultAvatar);
 
-            OAuth oauth = OAuth.create(member, provider, String.valueOf(i));
+            // ✅ 기본 아바타 소유 등록
+            OwnedAvatar ownedAvatar = OwnedAvatar.create(member, defaultAvatar);
+            member.addOwnedAvatar(ownedAvatar); // 양방향 연결
 
             memberRepository.save(member);
-            oAuthRepository.save(oauth);
+            oAuthRepository.save(OAuth.create(member, provider, String.valueOf(i)));
+            ownedAvatarRepository.save(ownedAvatar); // 반드시 저장
         }
     }
+
 
 
     @Transactional
     public void adminInit() {
-        if (memberRepository.findByEmail("admin@quizzle.com").isPresent()) {
-            return;
-        }
-
-        if (memberRepository.findByEmail("member@quizzle.com").isPresent()) {
-            return;
-        }
+        if (memberRepository.findByEmail("admin@quizzle.com").isPresent()) return;
+        if (memberRepository.findByEmail("member@quizzle.com").isPresent()) return;
 
         Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
             .orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
-
         Member testAdmin = Member.create("admin", "admin@quizzle.com", defaultAvatar);
         testAdmin.changeRole(Role.ADMIN);
+        OwnedAvatar adminAvatar = OwnedAvatar.create(testAdmin, defaultAvatar);
+        testAdmin.addOwnedAvatar(adminAvatar);
 
         Member testMember = Member.create("member", "member@quizzle.com", defaultAvatar);
-
-        OAuth testAdminOauth = OAuth.create(testAdmin, "kakao", "51");
-        OAuth testMemberOauth2 = OAuth.create(testMember, "google", "52");
+        OwnedAvatar memberAvatar = OwnedAvatar.create(testMember, defaultAvatar);
+        testMember.addOwnedAvatar(memberAvatar);
 
         memberRepository.save(testAdmin);
         memberRepository.save(testMember);
-        oAuthRepository.save(testAdminOauth);
-        oAuthRepository.save(testMemberOauth2);
+        oAuthRepository.save(OAuth.create(testAdmin, "kakao", "51"));
+        oAuthRepository.save(OAuth.create(testMember, "google", "52"));
+        ownedAvatarRepository.save(adminAvatar);
+        ownedAvatarRepository.save(memberAvatar);
     }
+
 
 
     @Transactional
     public void avatarInit() {
-        if (avatarRepository.count() > 0) return;
-
-        Avatar defaultAvatar = Avatar.builder()
-            .fileName("새콩이")
-            .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EA%B8%B0%EB%B3%B8+%EC%95%84%EB%B0%94%ED%83%80.png")
-            .price(0)
-            .status(AvatarStatus.OWNED)
-            .build();
-
-        Avatar nerdySaekong = Avatar.builder()
-            .fileName("안경쓴 새콩이")
-            .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EC%95%88%EA%B2%BD%EC%93%B4+%EC%83%88%EC%BD%A9%EC%9D%B4.png")
-            .price(300)
-            .status(AvatarStatus.AVAILABLE)
-            .build();
-
-        avatarRepository.save(defaultAvatar);
-        avatarRepository.save(nerdySaekong);
+        for (AvatarTemplate template : AvatarTemplate.values()) {
+            boolean exists = avatarRepository.existsByFileName(template.fileName);
+            if (!exists) {
+                avatarRepository.save(template.toEntity());
+            }
+        }
     }
 
 }

--- a/src/main/java/com/ll/quizzle/global/initdata/ProdInitData.java
+++ b/src/main/java/com/ll/quizzle/global/initdata/ProdInitData.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
-import com.ll.quizzle.domain.avatar.type.AvatarStatus;
+import com.ll.quizzle.domain.avatar.type.AvatarTemplate;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,26 +26,11 @@ public class ProdInitData {
 
     @Transactional
     public void initAvatars() {
-        if (!avatarRepository.existsByFileName("새콩이")) {
-            Avatar saekong = Avatar.builder()
-                .fileName("새콩이")
-                .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EA%B8%B0%EB%B3%B8+%EC%95%84%EB%B0%94%ED%83%80.png")
-                .price(0)
-                .status(AvatarStatus.AVAILABLE)
-                .build();
-
-            avatarRepository.save(saekong);
-        }
-
-        if (!avatarRepository.existsByFileName("안경쓴 새콩이")) {
-            Avatar nerdySaekong = Avatar.builder()
-                .fileName("안경쓴 새콩이")
-                .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EC%95%88%EA%B2%BD%EC%93%B4+%EC%83%88%EC%BD%A9%EC%9D%B4.png")
-                .price(300)
-                .status(AvatarStatus.AVAILABLE)
-                .build();
-
-            avatarRepository.save(nerdySaekong);
+        for (AvatarTemplate template : AvatarTemplate.values()) {
+            if (!avatarRepository.existsByFileName(template.fileName)) {
+                Avatar avatar = template.toEntity();
+                avatarRepository.save(avatar);
+            }
         }
     }
 }

--- a/src/main/java/com/ll/quizzle/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/quizzle/global/security/oauth2/CustomOAuth2UserService.java
@@ -9,9 +9,12 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.member.service.MemberService;
@@ -31,6 +34,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final OAuthRepository oAuthRepository;
     private final MemberRepository memberRepository;
     private final AvatarRepository avatarRepository;
+    private final OwnedAvatarRepository ownedAvatarRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -48,6 +52,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
     }
 
+
     private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oauth2User) {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
 
@@ -57,10 +62,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         switch (registrationId) {
             case "kakao" -> {
-                Map<String, Object> kakaoAccount = (Map<String, Object>) oauth2User.getAttributes().get("kakao_account");
-                Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-                email = (String) kakaoAccount.get("email");
-                name = (String) profile.get("nickname");
+                Map<String, Object> kakaoAccount = (Map<String, Object>)oauth2User.getAttributes().get("kakao_account");
+                Map<String, Object> profile = (Map<String, Object>)kakaoAccount.get("profile");
+                email = (String)kakaoAccount.get("email");
+                name = (String)profile.get("nickname");
                 oauthId = String.valueOf(oauth2User.getAttributes().get("id"));
                 log.debug("카카오 로그인 정보 - email: {}, name: {}, id: {}", email, name, oauthId);
             }
@@ -85,19 +90,27 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (existingMember.isPresent()) {
             member = existingMember.get();
         } else {
-            // 기본 아바타 조회
+
             Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
                 .orElseThrow(ErrorCode.AVATAR_NOT_FOUND::throwServiceException);
 
-            // 새로운 사용자 생성 (기본 아바타 포함)
             member = Member.create(
                 "GUEST-" + UUID.randomUUID().toString().substring(0, 6),
                 email,
                 defaultAvatar
             );
+
             memberRepository.save(member);
 
+            boolean alreadyOwned = member.hasAvatar(defaultAvatar);
+            if (!alreadyOwned) {
+                OwnedAvatar ownedAvatar = OwnedAvatar.create(member, defaultAvatar);
+                member.addOwnedAvatar(ownedAvatar);
+                ownedAvatarRepository.save(ownedAvatar);
+            }
+
             oAuthRepository.save(OAuth.create(member, registrationId, oauthId));
+
         }
 
         return new SecurityUser(

--- a/src/test/java/com/ll/quizzle/domain/avatar/AdminAvatarControllerTest.java
+++ b/src/test/java/com/ll/quizzle/domain/avatar/AdminAvatarControllerTest.java
@@ -1,6 +1,5 @@
 package com.ll.quizzle.domain.avatar;
 
-import static com.ll.quizzle.global.exceptions.ErrorCode.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -17,8 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ll.quizzle.domain.avatar.entity.Avatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.member.service.AuthTokenService;
@@ -47,6 +46,9 @@ class AdminAvatarControllerTest {
 	private AvatarRepository avatarRepository;
 
 	@Autowired
+	private OwnedAvatarRepository ownedAvatarRepository;
+
+	@Autowired
 	private OAuthRepository oAuthRepository;
 
 	@Autowired
@@ -57,19 +59,16 @@ class AdminAvatarControllerTest {
 
 	@BeforeEach
 	void setUp() {
-		Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
-			.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
-
 		Member adminMember = TestMemberFactory.createOAuthMember(
 			"관리자", "admin@email.com", "google", "1234",
-			memberRepository, oAuthRepository, defaultAvatar
+			memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
 		);
 		adminMember.changeRole(Role.ADMIN);
 		memberRepository.save(adminMember);
 
 		Member testmember = TestMemberFactory.createOAuthMember(
 			"유저2", "user2@email.com", "google", "2345",
-			memberRepository, oAuthRepository, defaultAvatar
+			memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
 		);
 		memberRepository.save(testmember);
 
@@ -79,6 +78,7 @@ class AdminAvatarControllerTest {
 		GeneratedToken token2 = authTokenService.generateToken(testmember.getEmail(), testmember.getRole().name());
 		memberCookie = new Cookie("access_token", token2.accessToken());
 	}
+
 
 	@Test
 	@DisplayName("관리자가 아바타 등록에 성공한다.")

--- a/src/test/java/com/ll/quizzle/domain/avatar/AvatarControllerTest.java
+++ b/src/test/java/com/ll/quizzle/domain/avatar/AvatarControllerTest.java
@@ -15,7 +15,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
+import com.ll.quizzle.domain.avatar.service.AvatarService;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.member.service.AuthTokenService;
@@ -40,6 +43,12 @@ class AvatarControllerTest {
 	private AvatarRepository avatarRepository;
 
 	@Autowired
+	private OwnedAvatarRepository ownedAvatarRepository;
+
+	@Autowired
+	private AvatarService avatarService;
+
+	@Autowired
 	private OAuthRepository oAuthRepository;
 
 	@Autowired
@@ -48,17 +57,19 @@ class AvatarControllerTest {
 	private Member member;
 	private Cookie accessTokenCookie;
 	private Avatar availableAvatar;
+	private Avatar defaultAvatar;
+
 
 	@BeforeEach
 	void setUp() {
-		Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
+		defaultAvatar = avatarRepository.findByFileName("새콩이")
 			.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
 		member = TestMemberFactory.createOAuthMember(
 			"구매자", "buyer@email.com", "google", "1234",
-			memberRepository, oAuthRepository, defaultAvatar
+			memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
 		);
-		member.increasePoint(500);
+		member.increasePoint(1000);
 		memberRepository.save(member);
 
 		availableAvatar = avatarRepository.findByFileName("안경쓴 새콩이")
@@ -80,16 +91,19 @@ class AvatarControllerTest {
 	@Test
 	@DisplayName("이미 소유한 아바타 구매 시도 시 실패")
 	void purchaseAvatar_alreadyOwned() throws Exception {
-		// 첫 구매
-		availableAvatar.purchase(member);
-		avatarRepository.save(availableAvatar);
+		OwnedAvatar owned = OwnedAvatar.create(member, availableAvatar);
+		member.addOwnedAvatar(owned);
+		ownedAvatarRepository.save(owned);
+		memberRepository.save(member);
 
+		// 동일 아바타 재구매 시도 → 실패 예상
 		mockMvc.perform(post("/api/v1/members/" + member.getId() + "/avatars/" + availableAvatar.getId())
 				.contentType(MediaType.APPLICATION_JSON)
 				.cookie(accessTokenCookie))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.msg").value("이미 소유한 아바타입니다."));
 	}
+
 
 	@Test
 	@DisplayName("보유 포인트가 부족한 경우 실패")
@@ -107,17 +121,24 @@ class AvatarControllerTest {
 	@Test
 	@DisplayName("소유한 아바타 목록 조회 성공")
 	void getOwnedAvatars_success() throws Exception {
-		// 미리 구매한 아바타 등록
-		availableAvatar.purchase(member);
-		avatarRepository.save(availableAvatar);
+
+		OwnedAvatar owned = OwnedAvatar.create(member, availableAvatar);
+		member.addOwnedAvatar(owned);
+		ownedAvatarRepository.save(owned);
+		memberRepository.save(member);
 
 		mockMvc.perform(get("/api/v1/members/" + member.getId() + "/avatars/owned")
 				.contentType(MediaType.APPLICATION_JSON)
 				.cookie(accessTokenCookie))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data").isArray())
-			.andExpect(jsonPath("$.data.length()").value(2));
+			.andExpect(jsonPath("$.data.length()").value(2))
+			.andExpect(jsonPath("$.data[*].id").value(org.hamcrest.Matchers.containsInAnyOrder(
+				defaultAvatar.getId().intValue(), availableAvatar.getId().intValue()
+			)));
 	}
+
+
 
 	@Test
 	@DisplayName("구매 가능한 아바타 목록 조회 성공")

--- a/src/test/java/com/ll/quizzle/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/ll/quizzle/domain/friend/service/FriendServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
 import com.ll.quizzle.domain.friend.dto.response.FriendListResponse;
 import com.ll.quizzle.domain.friend.dto.response.FriendOfferListResponse;
 import com.ll.quizzle.domain.friend.dto.response.FriendOfferResponse;
@@ -43,6 +44,9 @@ public class FriendServiceTest {
     @Autowired
     private AvatarRepository avatarRepository;
 
+    @Autowired
+    private OwnedAvatarRepository ownedAvatarRepository;
+
     private Member testMember;
     private Member secondMember;
     private Member thirdMember;
@@ -54,18 +58,18 @@ public class FriendServiceTest {
             .orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
 
         testMember = TestMemberFactory.createOAuthMember(
-                "테스트유저1", "test1@email.com", "google", "1234",
-                memberRepository, oAuthRepository, defaultAvatar
+            "테스트유저1", "test1@email.com", "google", "1234",
+            memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
         );
 
         secondMember = TestMemberFactory.createOAuthMember(
-                "테스트유저2", "test2@email.com", "google", "2345",
-                memberRepository, oAuthRepository, defaultAvatar
+            "테스트유저2", "test2@email.com", "google", "2345",
+            memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
         );
 
         thirdMember = TestMemberFactory.createOAuthMember(
-                "테스트유저3", "test3@email.com", "google", "3456",
-                memberRepository, oAuthRepository, defaultAvatar
+            "테스트유저3", "test3@email.com", "google", "3456",
+            memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
         );
     }
 
@@ -81,8 +85,8 @@ public class FriendServiceTest {
 
         // Then
         assertThat(friendResponse)
-                .extracting("fromMemberId", "toMemberId", "status")
-                .containsExactly(testMemberId, secondMemberId, FriendRequestStatus.PENDING.name());
+            .extracting("fromMemberId", "toMemberId", "status")
+            .containsExactly(testMemberId, secondMemberId, FriendRequestStatus.PENDING.name());
     }
 
     @Test
@@ -93,9 +97,9 @@ public class FriendServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> friendService.sendFriendOffer(testMemberId, testMemberId))
-                .isInstanceOf(ServiceException.class)
-                .extracting("msg")
-                .isEqualTo(ErrorCode.FRIEND_REQUEST_NOT_YOURSELF.getMessage());
+            .isInstanceOf(ServiceException.class)
+            .extracting("msg")
+            .isEqualTo(ErrorCode.FRIEND_REQUEST_NOT_YOURSELF.getMessage());
     }
 
     @Test
@@ -111,9 +115,9 @@ public class FriendServiceTest {
 
         // Then
         assertThatThrownBy(() -> friendService.sendFriendOffer(testMemberId, secondMemberId))
-                .isInstanceOf(ServiceException.class)
-                .extracting("msg")
-                .isEqualTo(ErrorCode.FRIEND_ALREADY_EXISTS.getMessage());
+            .isInstanceOf(ServiceException.class)
+            .extracting("msg")
+            .isEqualTo(ErrorCode.FRIEND_ALREADY_EXISTS.getMessage());
     }
 
     @Test
@@ -128,9 +132,9 @@ public class FriendServiceTest {
 
         // Then
         assertThatThrownBy(() -> friendService.sendFriendOffer(testMemberId, secondMemberId))
-                .isInstanceOf(ServiceException.class)
-                .extracting("msg")
-                .isEqualTo(ErrorCode.FRIEND_REQUEST_ALREADY_EXISTS.getMessage());
+            .isInstanceOf(ServiceException.class)
+            .extracting("msg")
+            .isEqualTo(ErrorCode.FRIEND_REQUEST_ALREADY_EXISTS.getMessage());
     }
 
     @Test
@@ -142,12 +146,13 @@ public class FriendServiceTest {
 
         // When
         friendService.sendFriendOffer(testMemberId, secondMemberId);
-        FriendOfferResponse friendOfferResponse = friendService.handleFriendOffer(secondMemberId, testMemberId, FriendRequestStatus.ACCEPTED);
+        FriendOfferResponse friendOfferResponse = friendService.handleFriendOffer(secondMemberId, testMemberId,
+            FriendRequestStatus.ACCEPTED);
 
         // Then
         assertThat(friendOfferResponse)
-                .extracting("memberId", "nickname", "status")
-                .containsExactly(testMemberId, testMember.getNickname(), FriendRequestStatus.ACCEPTED.name());
+            .extracting("memberId", "nickname", "status")
+            .containsExactly(testMemberId, testMember.getNickname(), FriendRequestStatus.ACCEPTED.name());
     }
 
     @Test
@@ -158,10 +163,11 @@ public class FriendServiceTest {
         long secondMemberId = secondMember.getId();
 
         // When & Then
-        assertThatThrownBy(() -> friendService.handleFriendOffer(secondMemberId, testMemberId, FriendRequestStatus.ACCEPTED))
-                .isInstanceOf(ServiceException.class)
-                .extracting("msg")
-                .isEqualTo(ErrorCode.FRIEND_REQUEST_NOT_FOUND.getMessage());
+        assertThatThrownBy(
+            () -> friendService.handleFriendOffer(secondMemberId, testMemberId, FriendRequestStatus.ACCEPTED))
+            .isInstanceOf(ServiceException.class)
+            .extracting("msg")
+            .isEqualTo(ErrorCode.FRIEND_REQUEST_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -183,16 +189,16 @@ public class FriendServiceTest {
         assertThat(targetFriendList).hasSize(1);
 
         assertThat(friendList.get(0))
-                .extracting("memberId", "nickname", "level")
-                .containsExactly(
-                        secondMemberId, secondMember.getNickname(), secondMember.getLevel()
-                );
+            .extracting("memberId", "nickname", "level")
+            .containsExactly(
+                secondMemberId, secondMember.getNickname(), secondMember.getLevel()
+            );
 
         assertThat(targetFriendList.get(0))
-                .extracting("memberId", "nickname", "level")
-                .containsExactly(
-                        testMemberId, testMember.getNickname(), testMember.getLevel()
-                );
+            .extracting("memberId", "nickname", "level")
+            .containsExactly(
+                testMemberId, testMember.getNickname(), testMember.getLevel()
+            );
     }
 
     @Test
@@ -204,12 +210,13 @@ public class FriendServiceTest {
 
         // When
         friendService.sendFriendOffer(testMemberId, secondMemberId);
-        FriendOfferResponse friendOfferResponse = friendService.handleFriendOffer(secondMemberId, testMemberId, FriendRequestStatus.REJECTED);
+        FriendOfferResponse friendOfferResponse = friendService.handleFriendOffer(secondMemberId, testMemberId,
+            FriendRequestStatus.REJECTED);
 
         // Then
         assertThat(friendOfferResponse)
-                .extracting("memberId", "nickname", "status")
-                .containsExactly(testMemberId, testMember.getNickname(), FriendRequestStatus.REJECTED.name());
+            .extracting("memberId", "nickname", "status")
+            .containsExactly(testMemberId, testMember.getNickname(), FriendRequestStatus.REJECTED.name());
     }
 
     @Test
@@ -220,10 +227,11 @@ public class FriendServiceTest {
         long secondMemberId = secondMember.getId();
 
         // When & Then
-        assertThatThrownBy(() -> friendService.handleFriendOffer(secondMemberId, testMemberId, FriendRequestStatus.REJECTED))
-                .isInstanceOf(ServiceException.class)
-                .extracting("msg")
-                .isEqualTo(ErrorCode.FRIEND_REQUEST_NOT_FOUND.getMessage());
+        assertThatThrownBy(
+            () -> friendService.handleFriendOffer(secondMemberId, testMemberId, FriendRequestStatus.REJECTED))
+            .isInstanceOf(ServiceException.class)
+            .extracting("msg")
+            .isEqualTo(ErrorCode.FRIEND_REQUEST_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -241,8 +249,8 @@ public class FriendServiceTest {
 
         // Then
         assertThat(friendResponse)
-                .extracting("fromMemberId", "toMemberId", "status")
-                .containsExactly(testMemberId, secondMemberId, FriendRequestStatus.PENDING.name());
+            .extracting("fromMemberId", "toMemberId", "status")
+            .containsExactly(testMemberId, secondMemberId, FriendRequestStatus.PENDING.name());
     }
 
     @Test
@@ -258,11 +266,11 @@ public class FriendServiceTest {
 
         // Then
         assertThat(friendOfferList)
-                .hasSize(1)
-                .extracting("memberId", "nickname")
-                .containsExactly(
-                        tuple(testMemberId, testMember.getNickname())
-                );
+            .hasSize(1)
+            .extracting("memberId", "nickname")
+            .containsExactly(
+                tuple(testMemberId, testMember.getNickname())
+            );
     }
 
     @Test
@@ -280,12 +288,12 @@ public class FriendServiceTest {
 
         // Then
         assertThat(friendOfferList)
-                .hasSize(2)
-                .extracting("memberId", "nickname")
-                .containsExactlyInAnyOrder(
-                        tuple(testMemberId, testMember.getNickname()),
-                        tuple(thirdMemberId, thirdMember.getNickname())
-                );
+            .hasSize(2)
+            .extracting("memberId", "nickname")
+            .containsExactlyInAnyOrder(
+                tuple(testMemberId, testMember.getNickname()),
+                tuple(thirdMemberId, thirdMember.getNickname())
+            );
     }
 
     @Test
@@ -303,18 +311,18 @@ public class FriendServiceTest {
 
         // Then
         assertThat(friendList)
-                .hasSize(1)
-                .extracting("memberId", "nickname", "level")
-                .containsExactly(
-                        tuple(secondMemberId, secondMember.getNickname(), secondMember.getLevel())
-                );
+            .hasSize(1)
+            .extracting("memberId", "nickname", "level")
+            .containsExactly(
+                tuple(secondMemberId, secondMember.getNickname(), secondMember.getLevel())
+            );
 
         assertThat(targetFriendList)
-                .hasSize(1)
-                .extracting("memberId", "nickname", "level")
-                .containsExactly(
-                        tuple(testMemberId, testMember.getNickname(), testMember.getLevel())
-                );
+            .hasSize(1)
+            .extracting("memberId", "nickname", "level")
+            .containsExactly(
+                tuple(testMemberId, testMember.getNickname(), testMember.getLevel())
+            );
     }
 
     @Test
@@ -349,12 +357,12 @@ public class FriendServiceTest {
 
         // Then
         assertThat(friendList)
-                .hasSize(2)
-                .extracting("memberId", "nickname")
-                .containsExactlyInAnyOrder(
-                        tuple(secondMemberId, secondMember.getNickname()),
-                        tuple(thirdMemberId, thirdMember.getNickname())
-                );
+            .hasSize(2)
+            .extracting("memberId", "nickname")
+            .containsExactlyInAnyOrder(
+                tuple(secondMemberId, secondMember.getNickname()),
+                tuple(thirdMemberId, thirdMember.getNickname())
+            );
     }
 
     @Test
@@ -397,8 +405,8 @@ public class FriendServiceTest {
 
         // Then
         assertThat(response)
-                .extracting("fromMemberId", "toMemberId", "status")
-                .containsExactly(testMemberId, secondMemberId, FriendRequestStatus.PENDING.name());
+            .extracting("fromMemberId", "toMemberId", "status")
+            .containsExactly(testMemberId, secondMemberId, FriendRequestStatus.PENDING.name());
     }
 
     @Test
@@ -410,8 +418,8 @@ public class FriendServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> friendService.deleteFriend(testMemberId, secondMemberId))
-                .isInstanceOf(ServiceException.class)
-                .extracting("msg")
-                .isEqualTo(ErrorCode.FRIEND_NOT_FOUND.getMessage());
+            .isInstanceOf(ServiceException.class)
+            .extracting("msg")
+            .isEqualTo(ErrorCode.FRIEND_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/ll/quizzle/domain/member/MemberAvatarEditTest.java
+++ b/src/test/java/com/ll/quizzle/domain/member/MemberAvatarEditTest.java
@@ -14,7 +14,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.member.service.AuthTokenService;
@@ -39,6 +41,9 @@ class MemberAvatarEditTest {
 	private AvatarRepository avatarRepository;
 
 	@Autowired
+	private OwnedAvatarRepository ownedAvatarRepository;
+
+	@Autowired
 	private OAuthRepository oAuthRepository;
 
 	@Autowired
@@ -51,30 +56,30 @@ class MemberAvatarEditTest {
 
 	@BeforeEach
 	void setUp() {
-		Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
-			.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
-
+		// Member 생성 및 기본 아바타 소유 처리
 		member = TestMemberFactory.createOAuthMember(
 			"바이어", "buyer@email.com", "google", "7777",
-			memberRepository, oAuthRepository, defaultAvatar
+			memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
 		);
 
-		ownedAvatar = Avatar.builder()
-			.fileName("소유한 아바타")
-			.url("https://url.com/owned.png")
-			.price(0)
-			.member(member)
-			.status(com.ll.quizzle.domain.avatar.type.AvatarStatus.OWNED)
-			.build();
-		avatarRepository.save(ownedAvatar);
+		ownedAvatar = avatarRepository.save(
+			Avatar.builder()
+				.fileName("소유한 아바타")
+				.url("https://url.com/owned.png")
+				.price(0)
+				.build()
+		);
 
-		notOwnedAvatar = Avatar.builder()
-			.fileName("소유하지 않은 아바타")
-			.url("https://url.com/notowned.png")
-			.price(100)
-			.status(com.ll.quizzle.domain.avatar.type.AvatarStatus.AVAILABLE)
-			.build();
-		avatarRepository.save(notOwnedAvatar);
+		member.addOwnedAvatar(OwnedAvatar.create(member, ownedAvatar));
+		ownedAvatarRepository.save(OwnedAvatar.create(member, ownedAvatar));
+
+		notOwnedAvatar = avatarRepository.save(
+			Avatar.builder()
+				.fileName("소유하지 않은 아바타")
+				.url("https://url.com/notowned.png")
+				.price(100)
+				.build()
+		);
 
 		GeneratedToken token = authTokenService.generateToken(member.getEmail(), member.getRole().name());
 		accessTokenCookie = new Cookie("access_token", token.accessToken());

--- a/src/test/java/com/ll/quizzle/domain/member/MemberControllerTest.java
+++ b/src/test/java/com/ll/quizzle/domain/member/MemberControllerTest.java
@@ -1,7 +1,7 @@
 package com.ll.quizzle.domain.member;
 
-import com.ll.quizzle.domain.avatar.entity.Avatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.member.service.AuthTokenService;
@@ -27,7 +27,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
-import static com.ll.quizzle.global.exceptions.ErrorCode.AVATAR_NOT_FOUND;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -40,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 @DirtiesContext
 class MemberControllerTest {
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -62,6 +62,9 @@ class MemberControllerTest {
     private AvatarRepository avatarRepository;
 
     @Autowired
+    private OwnedAvatarRepository ownedAvatarRepository;
+
+    @Autowired
     private MemberService memberService;
 
     @Mock
@@ -72,32 +75,34 @@ class MemberControllerTest {
 
     @BeforeEach
     void setUp() {
-
-        Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
-            .orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
-        // 테스트 유저 생성
+        // ✅ 기본 아바타 포함 테스트 멤버 생성
         member = TestMemberFactory.createOAuthMember(
-                "테스트유저", "test@email.com", "google", "1234",
-                memberRepository, oAuthRepository, defaultAvatar
+            "테스트유저",
+            "test@email.com",
+            "google",
+            "1234",
+            memberRepository,
+            oAuthRepository,
+            avatarRepository,
+            ownedAvatarRepository
         );
 
+        // ✅ Security MockMvc + 필터 설정
         mockMvc = MockMvcBuilders
-                .webAppContextSetup(context)
-                .addFilter(jwtAuthFilter)
-                .apply(springSecurity())
-                .alwaysDo(print())
-                .build();
+            .webAppContextSetup(context)
+            .addFilter(jwtAuthFilter)
+            .apply(springSecurity())
+            .alwaysDo(print())
+            .build();
 
-        memberRepository.save(member);
-
-        // 토큰 생성
+        // ✅ 토큰 생성
         generatedTokens = authTokenService.generateToken(
-                member.getEmail(),
-                member.getRole().toString()
+            member.getEmail(),
+            member.getRole().toString()
         );
 
+        // ✅ Rq Mock 주입
         ReflectionTestUtils.setField(memberService, "rq", rq);
-
         when(rq.getActor()).thenReturn(member);
 
         SecurityContextHolder.clearContext();
@@ -107,16 +112,16 @@ class MemberControllerTest {
     @DisplayName("프로필 정보 조회 (인증 필요 없음)")
     void testGetProfile() throws Exception {
         mockMvc.perform(get("/api/v1/members/{memberId}", member.getId()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(member.getId()))
-                .andExpect(jsonPath("$.data.nickname").value(member.getNickname()));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.id").value(member.getId()))
+            .andExpect(jsonPath("$.data.nickname").value(member.getNickname()));
     }
 
     @Test
     @DisplayName("프로필 정보 조회 실패 - 없는 회원 (99999999)")
     void testGetProfileWithNoMember() throws Exception {
         mockMvc.perform(get("/api/v1/members/99999999"))
-                .andExpect(status().isNotFound());
+            .andExpect(status().isNotFound());
     }
 
     @Test
@@ -127,9 +132,9 @@ class MemberControllerTest {
         accessTokenCookie.setHttpOnly(true);
 
         mockMvc.perform(get("/api/v1/members/me")
-                        .cookie(accessTokenCookie))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(member.getId()))
-                .andExpect(jsonPath("$.data.nickname").value(member.getNickname()));
+                .cookie(accessTokenCookie))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.id").value(member.getId()))
+            .andExpect(jsonPath("$.data.nickname").value(member.getNickname()));
     }
 }

--- a/src/test/java/com/ll/quizzle/domain/member/MemberNicknameEditTest.java
+++ b/src/test/java/com/ll/quizzle/domain/member/MemberNicknameEditTest.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ll.quizzle.domain.avatar.entity.Avatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.member.service.AuthTokenService;
@@ -49,6 +50,9 @@ class MemberNicknameEditTest {
     private AvatarRepository avatarRepository;
 
     @Autowired
+    private OwnedAvatarRepository ownedAvatarRepository;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     private Member member;
@@ -58,17 +62,18 @@ class MemberNicknameEditTest {
 
     @BeforeEach
     void setUp() {
+        member = TestMemberFactory.createOAuthMember(
+            "테스트유저", "test@email.com", "google", "1234",
+            memberRepository, oauthRepository, avatarRepository, ownedAvatarRepository
+        );
 
-        defaultAvatar = avatarRepository.findByFileName("새콩이")
-            .orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
-
-        member = TestMemberFactory.createOAuthMember("테스트유저", "test@email.com", "google", "1234", memberRepository, oauthRepository, defaultAvatar);
         member.increasePoint(100); // 초기 포인트 설정
         memberRepository.save(member);
 
         GeneratedToken token = authTokenService.generateToken(member.getEmail(), member.getRole().name());
         accessTokenCookie = new Cookie("access_token", token.accessToken());
     }
+
 
     @Test
     @DisplayName("닉네임 변경 성공")
@@ -105,7 +110,7 @@ class MemberNicknameEditTest {
                 .cookie(accessTokenCookie)
                 .content(objectMapper.writeValueAsString(Map.of("nickname", " "))))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 2자 이상 20자 이하로 입력해주세요.")));
+            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임이 유효하지 않습니다.")));
     }
 
     @Test
@@ -116,7 +121,7 @@ class MemberNicknameEditTest {
                 .cookie(accessTokenCookie)
                 .content(objectMapper.writeValueAsString(Map.of("nickname", "A"))))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 2자 이상 20자 이하로 입력해주세요.")));
+            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 2자 이상 20자 이하이어야 합니다.")));
     }
 
     @Test
@@ -127,13 +132,25 @@ class MemberNicknameEditTest {
                 .cookie(accessTokenCookie)
                 .content(objectMapper.writeValueAsString(Map.of("nickname", "Invalid@Nick"))))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.msg").value("닉네임은 영문, 숫자, 한글만 사용할 수 있습니다."));
+            .andExpect(jsonPath("$.msg").value(org.hamcrest.Matchers.containsString("닉네임은 영문, 숫자, 한글만 사용할 수 있습니다.")));
+
     }
 
     @Test
     @DisplayName("중복된 닉네임일 때")
     void updateNickname_duplicate() throws Exception {
-        TestMemberFactory.createOAuthMember("중복닉네임", "duplicate@email.com", "google", "5678", memberRepository, oauthRepository, defaultAvatar);
+        // 중복 닉네임을 가진 사용자 생성 (기본 아바타 소유 포함)
+        TestMemberFactory.createOAuthMember(
+            "중복닉네임",
+            "duplicate@email.com",
+            "google",
+            "5678",
+            memberRepository,
+            oauthRepository,
+            avatarRepository,
+            ownedAvatarRepository
+        );
+
         mockMvc.perform(patch("/api/v1/members/" + member.getId() + "/nickname")
                 .contentType(MediaType.APPLICATION_JSON)
                 .cookie(accessTokenCookie)
@@ -141,4 +158,5 @@ class MemberNicknameEditTest {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.msg").value("이미 존재하는 닉네임입니다."));
     }
+
 }

--- a/src/test/java/com/ll/quizzle/domain/point/PointControllerTest.java
+++ b/src/test/java/com/ll/quizzle/domain/point/PointControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
 import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
 import com.ll.quizzle.domain.member.service.AuthTokenService;
@@ -46,27 +47,28 @@ class PointControllerTest {
 	@Autowired
 	private OAuthRepository oAuthRepository;
 
+	@Autowired
+	private AvatarRepository avatarRepository;
+
+	@Autowired
+	private OwnedAvatarRepository ownedAvatarRepository;
+
 	private Member member;
 	private Member other;
 	private Cookie accessTokenCookie;
 
-	@Autowired
-	private AvatarRepository avatarRepository;
-
 	@BeforeEach
 	void setUp() {
-
-		Avatar defaultAvatar = avatarRepository.findByFileName("새콩이")
-			.orElseThrow(AVATAR_NOT_FOUND::throwServiceException);
-		// 테스트 유저 생성
+		// 테스트 유저 생성 (기본 아바타 장착 및 소유 포함)
 		member = TestMemberFactory.createOAuthMember(
 			"테스트유저", "test@email.com", "google", "1234",
-			memberRepository, oAuthRepository, defaultAvatar
+			memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
 		);
 
+		// 다른 유저도 동일하게 처리
 		other = TestMemberFactory.createOAuthMember(
 			"다른유저", "other@email.com", "google", "5678",
-			memberRepository, oAuthRepository, defaultAvatar
+			memberRepository, oAuthRepository, avatarRepository, ownedAvatarRepository
 		);
 
 		// 포인트 내역 생성
@@ -77,6 +79,7 @@ class PointControllerTest {
 		GeneratedToken token = authTokenService.generateToken(member.getEmail(), member.getRole().name());
 		accessTokenCookie = new Cookie("access_token", token.accessToken());
 	}
+
 
 	@Test
 	@DisplayName("포인트 내역 전체 조회 성공")

--- a/src/test/java/com/ll/quizzle/factory/TestMemberFactory.java
+++ b/src/test/java/com/ll/quizzle/factory/TestMemberFactory.java
@@ -1,20 +1,45 @@
 package com.ll.quizzle.factory;
 
 import com.ll.quizzle.domain.avatar.entity.Avatar;
+import com.ll.quizzle.domain.avatar.entity.OwnedAvatar;
+import com.ll.quizzle.domain.avatar.repository.AvatarRepository;
+import com.ll.quizzle.domain.avatar.repository.OwnedAvatarRepository;
+import com.ll.quizzle.domain.avatar.type.AvatarTemplate;
 import com.ll.quizzle.domain.member.entity.Member;
 import com.ll.quizzle.domain.member.repository.MemberRepository;
+import com.ll.quizzle.global.exceptions.ErrorCode;
 import com.ll.quizzle.global.security.oauth2.entity.OAuth;
 import com.ll.quizzle.global.security.oauth2.repository.OAuthRepository;
 
 public class TestMemberFactory {
 
-	public static Member createOAuthMember(String nickname, String email, String provider, String oauthId,
-		MemberRepository memberRepo, OAuthRepository oauthRepo, Avatar avatar) {
-		Member member = Member.create(nickname, email, avatar);
+	public static Member createOAuthMember(
+		String nickname,
+		String email,
+		String provider,
+		String oauthId,
+		MemberRepository memberRepo,
+		OAuthRepository oauthRepo,
+		AvatarRepository avatarRepo,
+		OwnedAvatarRepository ownedAvatarRepo) {
+
+		Avatar defaultAvatar = avatarRepo.findByFileName(AvatarTemplate.DEFAULT.fileName)
+			.orElseThrow(ErrorCode.AVATAR_NOT_FOUND::throwServiceException);
+
+		Member member = Member.create(nickname, email, defaultAvatar);
 		memberRepo.save(member);
 
 		OAuth oauth = OAuth.create(member, provider, oauthId);
 		oauthRepo.save(oauth);
+
+		if (!member.hasAvatar(defaultAvatar)) {
+			OwnedAvatar owned = OwnedAvatar.create(member, defaultAvatar);
+			member.addOwnedAvatar(owned);
+			ownedAvatarRepo.save(owned);
+		}
+
+		member.changeAvatar(defaultAvatar);
+		memberRepo.save(member);
 
 		return member;
 	}

--- a/src/test/java/com/ll/quizzle/global/security/oauth2/OAuth2AuthenticationTest.java
+++ b/src/test/java/com/ll/quizzle/global/security/oauth2/OAuth2AuthenticationTest.java
@@ -79,7 +79,6 @@ public class OAuth2AuthenticationTest {
             .fileName("새콩이")
             .url("https://quizzle-avatars.s3.ap-northeast-2.amazonaws.com/%EA%B8%B0%EB%B3%B8+%EC%95%84%EB%B0%94%ED%83%80.png")
             .price(0)
-            .status(AvatarStatus.OWNED)
             .build());
 
         testMember = Member.builder()
@@ -96,10 +95,10 @@ public class OAuth2AuthenticationTest {
 
         // 테스트용 OAuth 정보 생성
         testOAuth = OAuth.builder()
-                .provider("google")
-                .oauthId("123456789")
-                .member(testMember)
-                .build();
+            .provider("google")
+            .oauthId("123456789")
+            .member(testMember)
+            .build();
 
         oAuthRepository.save(testOAuth);
         memberRepository.save(testMember);
@@ -134,9 +133,9 @@ public class OAuth2AuthenticationTest {
 
         // when & then
         mockMvc.perform(get("/api/v1/members/{memberId}/points", testMember.getId())
-                        .cookie(accessTokenCookie))
-                .andDo(print())
-                .andExpect(status().isOk());
+                .cookie(accessTokenCookie))
+            .andDo(print())
+            .andExpect(status().isOk());
     }
 
     @Test
@@ -145,9 +144,9 @@ public class OAuth2AuthenticationTest {
         // given
         // 인증 정보 생성
         Authentication auth = new UsernamePasswordAuthenticationToken(
-                testMember,
-                null,
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_MEMBER"))
+            testMember,
+            null,
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_MEMBER"))
         );
 
         // when
@@ -184,6 +183,6 @@ public class OAuth2AuthenticationTest {
 
         // when & then
         assertThat(oAuthRepository.findByProviderAndOauthIdWithMember(invalidProvider, oauthId))
-                .isEmpty();
+            .isEmpty();
     }
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[1] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 기능에서 어떤 부분이 구현되었는지 설명해주세요
- Avatar 테이블 분리에 따른 테스트 코드 수정
- Avatar 소유 구조 분리 및 관련 비즈니스 로직 리팩토링
- Avatar 관련 initData 수정
- 아바타 구매용 applyPointPolicy 추가